### PR TITLE
 Remove freegeoip and write sorted history

### DIFF
--- a/run.py
+++ b/run.py
@@ -21,29 +21,35 @@ def do_ndt_test(country_code=""):
     """Runs the NDT test as a subprocess and returns the raw results.
 
     Args:
-       `country_code`: A capitalized, two-letter country code representing the location of
-           the desired test server. If no country code is supplied, the script uses the default mlab_ns
-           behavior.
+      `country_code`: A capitalized, two-letter country code representing the
+          location of the desired test server. If no country code is supplied,
+          the script uses the default mlab_ns behavior.
     Returns:
        The STDOUT of the call to `measurement_kit`.
     """
     now = int(subprocess.check_output(["date", "-u", "+%s"]))
-    if country_code == "": # If there is a country code, use it, otherwise default
-        # We are using the `-g` flag due to a regex stack overflow segmentation fault bug in GNU's C++ library
-        # Measurement-kit issue #1276: https://github.com/measurement-kit/measurement-kit/issues/1276
-        result_raw = subprocess.check_output(["/test-runner/measurement_kit", "-g",
-            "--reportfile=/data/ndt-%d.njson"%now, "ndt"])
+    if country_code == "":
+        # If there is a country code, use it, otherwise default We are using
+        # the `-g` flag due to a regex stack overflow segmentation fault bug
+        # in GNU's C++ library Measurement-kit issue #1276:
+        # https://github.com/measurement-kit/measurement-kit/issues/1276
+        result_raw = subprocess.check_output(
+            ["/test-runner/measurement_kit", "-g",
+             "--reportfile=/data/ndt-%d.njson"%now, "ndt"])
     else:
-        result_raw = subprocess.check_output(["/test-runner/measurement_kit", "-g",
-            "--reportfile=/data/ndt-%d.njson"%now, "ndt", "-C", country_code])
+        result_raw = subprocess.check_output(
+            ["/test-runner/measurement_kit", "-g",
+             "--reportfile=/data/ndt-%d.njson"%now, "ndt", "-C", country_code])
     return result_raw
+
 
 def summarize_tests():
     """Converts measurement_kit .njson test results into a single .csv file.
 
-    This function checks the `/data/` directory for all files, reads the json into an object and writes
-    the object into a csv file that it stores in `/share/history.csv` (the `share` directory is shared
-    between this Docker image and the dashboard image).
+    This function checks the `/data/` directory for all files, reads the json
+    into an object and writes the object into a csv file that it stores in
+    `/share/history.csv` (the `share` directory is shared between this Docker
+    image and the dashboard image).
     """
     with tempfile.NamedTemporaryFile(delete=False) as tmpfile: 
         historywriter = csv.writer(tmpfile)
@@ -51,14 +57,18 @@ def summarize_tests():
         for file in sorted(os.listdir("/data")):
             with open("/data/" + file) as json_data:
                 try:
-                  d = json.load(json_data)
-                  historywriter.writerow([d["measurement_start_time"], d["test_keys"]["simple"]["download"], d["test_keys"]["simple"]["upload"]])
+                    d = json.load(json_data)
+                    historywriter.writerow([
+                        d["measurement_start_time"],
+                        d["test_keys"]["simple"]["download"],
+                        d["test_keys"]["simple"]["upload"]])
                 except Exception as e:
-                  logging.error('Failed to write row %s', e)
-                  pass
+                    logging.error('Failed to write row %s', e)
+                    pass
         tmp_loc = tmpfile.name
     logging.info("Updating /share/history.csv")
     shutil.move(tmp_loc, "/share/history.csv")
+
 
 def perform_test_loop(expected_sleep_secs=12*60*60):
     """The main loop of the script.
@@ -80,9 +90,12 @@ def perform_test_loop(expected_sleep_secs=12*60*60):
             logging.error('Error in NDT test: %s', ex)
         summarize_tests()
         sleeptime = random.expovariate(1.0/expected_sleep_secs)
-        resume_time = datetime.datetime.utcnow() + datetime.timedelta(seconds=sleeptime)
-        logging.info('Sleeping for %u seconds (until %s)', sleeptime, resume_time)
+        resume_time = (datetime.datetime.utcnow() +
+                       datetime.timedelta(seconds=sleeptime))
+        logging.info(
+            'Sleeping for %u seconds (until %s)', sleeptime, resume_time)
         time.sleep(sleeptime)
+
 
 if __name__ == "__main__":
     root_log = logging.getLogger()


### PR DESCRIPTION
This change removes support for freegeoip since it no longer works: https://github.com/m-lab/murakami/issues/6

This change catches exceptions and skips files with corrupted data: https://github.com/m-lab/murakami/issues/7

The change causes the history.csv output to be sorted chronologically: https://github.com/m-lab/murakami/issues/8

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/9)
<!-- Reviewable:end -->
