### PR TITLE
Working Dockerfile.template for Balena deployments.

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -49,7 +49,4 @@ RUN poetry config settings.virtualenvs.create false \
 # Add binaries' path to PATH.
 ENV PATH="/murakami/bin:${PATH}"
 
-# Mount the expected system path for saving data
-VOLUME ["/data/", "/var/lib/murakami"]
-
-ENTRYPOINT [ "murakami", "-c", "/murakami/murakami.toml" ]
+ENTRYPOINT [ "murakami", "-d", "/data/config.json", "-c", "/murakami/murakami.toml" ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -49,4 +49,7 @@ RUN poetry config settings.virtualenvs.create false \
 # Add binaries' path to PATH.
 ENV PATH="/murakami/bin:${PATH}"
 
-ENTRYPOINT [ "python", "-m", "murakami" ]
+# Mount the expected system path for saving data
+VOLUME ["/data/", "/var/lib/murakami"]
+
+ENTRYPOINT [ "murakami", "-c", "/murakami/murakami.toml" ]


### PR DESCRIPTION
This PR updates `Dockerfile.template` to work with Balena.io cloud build deployments. 
- BalenaOS mounts `/data/` as the persistent storage volume for all Balena managed containers, so we have to map the murakami daemon's expected path `/var/lib/murakami` to that volume.
- Since we are installing murakami into the container and adding it to the path, we can call it as a binary instead of through python
- Entrypoint modified to include use of a `murakami.toml` config file. 

Testing procedure:
- install BalenaOS on a device and add it to test project
- customize `murakami.toml`
- copy `keys` folder into local clone, containing SSH and GCP keys
- push release to Balena to kick off cloud build & device update: `balena push <project name> -c`

Contents of `murakami.toml`:
```
$ cat ../murakami-configs-keys/murakami.toml 
[settings]
port = 80
loglevel = "DEBUG"
immediate = 1
hostname = "bmore_murakami_balena"
webthings = 1
location = "bmore_balena"
network_type = "home"
connection_type = "wired"

[exporters]

  [exporters.local]
  type = "local"
  enabled = true
  path = "/data/"

  [exporters.gcs]
  type = "gcs"
  enabled = true
  target = "gs://critzo-murakami-gcs-test/"
  account = "critzo-murakami-test-gcs@mlab-sandbox.iam.gserviceaccount.com"
  key = "/murakami/keys/critzo-murakami-gcs-serviceaccount.json"

  [exporters.scp]
  type = "scp"
  enabled = true
  target = "chelsea.mayfirst.org:murakami-export-test/"
  port = 22
  username = "critzo"
  key = "/murakami/keys/id_rsa_murakami"
```

**Notes for continued development:**
Despite being a working config, there were some issues encountered that require additional troubleshooting:

- _Supporting all variables in murakami.toml_:
  - In this testing example, all values from `murakami.toml` were read, except for those that are intended to be used in exported filenames: `location = "bmore_balena"`, `network_type = "home"`, `connection_type = "wired"`.
  - exporters saved test results, but did not include these variables in the name:
  ```
  bash-5.0# ls -la /data/
  total 88
  drwxr-xr-x    2 root     root          4096 Oct 29 13:46 .
  drwxr-xr-x    1 root     root          4096 Oct 29 13:58 ..
  -rw-r--r--    1 root     root          7837 Oct 29 13:44 DASH-2019-10-29T13:44:06.536725.jsonl
  -rw-r--r--    1 root     root           776 Oct 29 13:46 Speedtest.net-2019-10-29T13:46:01.297312.jsonl
  -rw-r--r--    1 root     root          8984 Oct 29 13:45 ndt5-2019-10-29T13:44:50.117465.jsonl
  -rw-r--r--    1 root     root         54130 Oct 29 13:45 ndt7-2019-10-29T13:45:26.876290.jsonl
  ```
  - After adding the `settings` section as Balena environment variables, the files were exported with the expected variables in the filenames:
  ```
  bash-5.0# ls -la /data/
  total 352
  drwxr-xr-x    2 root     root          4096 Oct 29 14:27 .
  drwxr-xr-x    1 root     root          4096 Oct 29 14:25 ..
  -rw-r--r--    1 root     root          7837 Oct 29 13:44 DASH-2019-10-29T13:44:06.536725.jsonl
  -rw-r--r--    1 root     root           776 Oct 29 13:46 Speedtest.net-2019-10-29T13:46:01.297312.jsonl
  -rw-r--r--    1 root     root          7837 Oct 29 14:25 dash-bmore_balena_env-home-wired-2019-10-29T14:25:16.194580.jsonl
  -rw-r--r--    1 root     root          8984 Oct 29 13:45 ndt5-2019-10-29T13:44:50.117465.jsonl
  -rw-r--r--    1 root     root          9845 Oct 29 14:26 ndt5-bmore_balena_env-home-wired-2019-10-29T14:25:59.058080.jsonl
  -rw-r--r--    1 root     root         54130 Oct 29 13:45 ndt7-2019-10-29T13:45:26.876290.jsonl
  -rw-r--r--    1 root     root         65298 Oct 29 14:27 ndt7-bmore_balena_env-home-wired-2019-10-29T14:26:37.959767.jsonl
  -rw-r--r--    1 root     root           776 Oct 29 14:27 speedtest.net-bmore_balena_env-home-wired-2019-10-29T14:27:12.718644.jsonl
  ```
- _Expected configuration file override behavior when setting Balena environment variables_:
  - We expect the config file variables to be overridden by Balena environment variables, selectively by section. For example, with the `murakami.toml` file above, an SCP and GCS exporter worked upon container start.
  - To test override, a Balena env var was added, expecting to disable only the SCP exporter: `MURAKAMI_EXPORTER_SCP_ENABLED=0`
  - The result was that all exporters were disabled.