### PR TITLE
Fix minor inconsistency between some configfile settings and their corresponding options

### DIFF
--- a/murakami.toml.example
+++ b/murakami.toml.example
@@ -3,8 +3,8 @@ port = 80
 loglevel = "DEBUG"
 immediate = 1
 location = "Baltimore"
-network_type = "home"
-connection_type = "wired"
+network-type = "home"
+connection-type = "wired"
 
 [exporters]
 

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -78,7 +78,7 @@ def main():
         config_file_parser_class=TomlConfigFileParser,
         default_config_files=defaults.CONFIG_FILES,
         description="The Murakami network test runner.",
-        ignore_unknown_config_file_keys=True,
+        ignore_unknown_config_file_keys=False,
     )
     parser.add(
         "-c",
@@ -128,7 +128,7 @@ def main():
     )
     parser.add(
         "-l",
-        "--log",
+        "--loglevel",
         dest="loglevel",
         default="DEBUG",
         choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],


### PR DESCRIPTION
There was a slight inconsistency between the naming of certain variables in the default configuration file and what those variables were rendered as in `__main__.py`. This pull request corrects those inconsistencies.