### PR TITLE
add summary flag to libndt5 client runner for simplified json output

### DIFF
--- a/murakami/runners/libndt5.py
+++ b/murakami/runners/libndt5.py
@@ -32,6 +32,7 @@ class LibndtClient(MurakamiRunner):
                 "--websocket",
                 "--tls",
                 "--batch",
+                "--summary"
             ]
 
             if "host" in self._config:


### PR DESCRIPTION
Updates the libndt runner for ndt5 tests to use the newly created `-summary` flag. @robertodauria PTAL?