### PR TITLE
Replace libndt with Go clients

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,12 @@ FROM golang:1.13.0-alpine3.10 AS build
 RUN apk add --no-cache git
 RUN go get github.com/m-lab/dash/cmd/dash-client
 RUN go get github.com/m-lab/ndt7-client-go/cmd/ndt7-client
+# TODO: just use go get after the -format and -quiet flags have been merged
+# into master.
+RUN git clone https://github.com/m-lab/ndt5-client-go.git \
+    && cd ndt5-client-go/cmd/ndt5-client \
+    && git checkout b179d3bd11fbdb33f1c7ba15130bf684f7e64910 \
+    && go install
 
 # Murakami image
 FROM python:3-alpine3.10

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,35 +1,27 @@
-# Builder image
-FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine:3.10 as build
-MAINTAINER Measurement Lab Support <support@measurementlab.net>
-
-RUN apk add --update build-base gcc cmake libressl-dev curl-dev git linux-headers
-
-# Download and build libndt.
-RUN git clone https://github.com/measurement-kit/libndt.git
-WORKDIR /libndt
-RUN git checkout 9369f65ad47dd4c21b1df69c609ddb1d6ef2d493
-
-RUN cmake .
-RUN cmake --build . -j $(nproc)
-
-# Build dash-client
-FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine-golang:1.12-3.10-build AS dashbuild
+# Build ndt7, ndt5 and dash Go clients.
+FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine-golang:1.12-3.10-build AS build
 RUN apk add --no-cache git
-RUN go get github.com/neubot/dash/cmd/dash-client
+RUN go get github.com/m-lab/dash/cmd/dash-client
+RUN go get github.com/m-lab/ndt7-client-go/cmd/ndt7-client
+# TODO: just use go get after the -format and -quiet flags have been merged
+# into master.
+RUN git clone https://github.com/m-lab/ndt5-client-go.git \
+    && cd ndt5-client-go/cmd/ndt5-client \
+    && git checkout b179d3bd11fbdb33f1c7ba15130bf684f7e64910 \
+    && go install
 
 # Murakami image
 FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine-python:3.7-edge
 RUN apk update && apk upgrade
 # Install dependencies and speedtest-cli
-RUN apk add git curl libstdc++ libgcc gcc libc-dev libffi-dev libressl-dev speedtest-cli make
+RUN apk add git libgcc gcc libc-dev libffi-dev libressl-dev speedtest-cli make
 RUN pip install 'poetry==0.12.17'
 
 WORKDIR /murakami
 
 # Copy Murakami and previously built test clients into the container.
 COPY . /murakami/
-COPY --from=build /libndt/libndt-client /murakami/bin/
-COPY --from=dashbuild /go/bin/dash-client /murakami/bin/
+COPY --from=build /go/bin/* /murakami/bin/
 
 # Set up poetry to not create a virtualenv, since the docker container is
 # isolated already, and install the required dependencies.

--- a/murakami/runners/ndt5.py
+++ b/murakami/runners/ndt5.py
@@ -11,8 +11,8 @@ from murakami.runner import MurakamiRunner
 logger = logging.getLogger(__name__)
 
 
-class LibndtClient(MurakamiRunner):
-    """Run LibNDT tests."""
+class Ndt5Client(MurakamiRunner):
+    """Run NDT5 test."""
     def __init__(self, config=None, data_cb=None):
         super().__init__(
             title="ndt5",
@@ -23,16 +23,11 @@ class LibndtClient(MurakamiRunner):
 
     def _start_test(self):
         logger.info("Starting NDT5 test...")
-        if shutil.which("libndt-client") is not None:
+        if shutil.which("ndt5-client") is not None:
             cmdargs = [
-                "libndt-client",
-                "--download",
-                "--upload",
-                "--json",
-                "--websocket",
-                "--tls",
-                "--batch",
-                "--summary"
+                "ndt5-client",
+                "-format=json",
+                "-quiet"
             ]
 
             if "host" in self._config:
@@ -52,7 +47,7 @@ class LibndtClient(MurakamiRunner):
             logger.info("NDT5 test complete.")
         else:
             raise RunnerError(
-                "libndt",
-                "Executable libndt-client does not exist, please install libndt.",
+                "ndt5-client",
+                "Executable ndt5-client does not exist, please install ndt5-client-go.",
             )
         return [*reader.iter(skip_empty=True, skip_invalid=True)]

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class Ndt7Client(MurakamiRunner):
-    """Run LibNDT tests."""
+    """Run ndt7 test."""
     def __init__(self, config=None, data_cb=None):
         super().__init__(
             title="ndt7",

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -22,7 +22,7 @@ class Ndt7Client(MurakamiRunner):
         )
 
     def _start_test(self):
-        logger.info("Starting NDT7 test...")
+        logger.info("Starting ndt7 test...")
         if shutil.which("ndt7-client") is not None:
             cmdargs = [
                 "ndt7-client",

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -11,7 +11,7 @@ from murakami.runner import MurakamiRunner
 logger = logging.getLogger(__name__)
 
 
-class LibndtClient(MurakamiRunner):
+class Ndt7Client(MurakamiRunner):
     """Run LibNDT tests."""
     def __init__(self, config=None, data_cb=None):
         super().__init__(
@@ -23,17 +23,11 @@ class LibndtClient(MurakamiRunner):
 
     def _start_test(self):
         logger.info("Starting NDT7 test...")
-        if shutil.which("libndt-client") is not None:
+        if shutil.which("ndt7-client") is not None:
             cmdargs = [
-                "libndt-client",
-                "--download",
-                "--upload",
-                "--json",
-                "--websocket",
-                "--tls",
-                "--ndt7",
-                "--batch",
-                "--summary",
+                "ndt7-client",
+                "-format=json",
+                "-quiet"
             ]
 
             if "host" in self._config:
@@ -52,7 +46,7 @@ class LibndtClient(MurakamiRunner):
             logger.info("NDT7 test complete.")
         else:
             raise RunnerError(
-                "libndt",
-                "Executable libndt-client does not exist, please install libndt.",
+                "ndt7-client",
+                "Executable ndt7-client does not exist, please install ndt7-client-go.",
             )
         return [*reader.iter(skip_empty=True, skip_invalid=True)]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ pytest-cov = "^2.8"
 [tool.poetry.plugins."murakami.runners"]
 "dash" = "murakami.runners.dash:DashClient"
 "ndt5" = "murakami.runners.libndt5:LibndtClient"
-"ndt7" = "murakami.runners.libndt7:LibndtClient"
+"ndt7" = "murakami.runners.ndt7:Ndt7Client"
 "speedtestmulti" = "murakami.runners.speedtest:SpeedtestClient"
 "speedtestsingle" = "murakami.runners.speedtestsingle:SpeedtestSingleClient"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ pytest-cov = "^2.8"
 
 [tool.poetry.plugins."murakami.runners"]
 "dash" = "murakami.runners.dash:DashClient"
-"ndt5" = "murakami.runners.libndt5:LibndtClient"
+"ndt5" = "murakami.runners.ndt5:Ndt5Client"
 "ndt7" = "murakami.runners.ndt7:Ndt7Client"
 "speedtestmulti" = "murakami.runners.speedtest:SpeedtestClient"
 "speedtestsingle" = "murakami.runners.speedtestsingle:SpeedtestSingleClient"


### PR DESCRIPTION
This PR removes [libndt](https://github.com/measurement-kit/libndt) from Murakami to use [ndt5-client-go](https://github.com/m-lab/ndt5-client-go) and [ndt7-client-go](https://github.com/m-lab/ndt7-client-go), instead. This change simplifies the Dockerfile and speeds up the build significantly.

Tested with `docker build .` on x86_64, testing on armv7 is in progress.

