### PR TITLE
Add parsers for ndt5/7 output format

### DIFF
--- a/murakami/exporters/gcs.py
+++ b/murakami/exporters/gcs.py
@@ -68,15 +68,9 @@ class GCSExporter(MurakamiExporter):
                     object_name += '/'
             object_name += test_filename
 
-            # Write JSONL output to a string.
-            fp = io.StringIO()
-            writer = jsonlines.Writer(fp)
-            writer.write_all(data)
-            writer.close()
-
             logger.info("Uploading test data - Bucket: %s, Object: %s",
                 bucket_name, object_name)
 
-            self.upload(fp.getvalue(), bucket_name, object_name)
+            self.upload(data, bucket_name, object_name)
         except ValueError as e:
             logger.error('Error while uploading to GCS: %s', e)

--- a/murakami/exporters/local.py
+++ b/murakami/exporters/local.py
@@ -35,8 +35,7 @@ class LocalExporter(MurakamiExporter):
                 self._path, self._generate_filename(test_name, timestamp))
             output = open(dst_path, "w")
             logger.info("Copying data to %s", dst_path)
-            with jsonlines.Writer(output) as writer:
-                writer.write_all(data)
+            output.write(data)
         except Exception as err:
             logger.error("Exporting to local file failed: %s", err)
         else:

--- a/murakami/exporters/scp.py
+++ b/murakami/exporters/scp.py
@@ -71,9 +71,7 @@ class SCPExporter(MurakamiExporter):
                 filename = self._generate_filename(test_name, timestamp)
                 dst_path = os.path.join(dst_path, filename)
                 logger.info("Copying data to %s", dst_path)
-                buf = io.StringIO()
-                with jsonlines.Writer(buf) as writer:
-                    writer.write_all(data)
+                buf = io.StringIO(data)
                 buf.seek(0)
                 scp.putfo(buf, dst_path)
         except Exception as err:

--- a/murakami/runner.py
+++ b/murakami/runner.py
@@ -25,11 +25,15 @@ class MurakamiRunner:
     MurakamiServer
     * `data_cb`: The callback function that receives the test results
     """
-    def __init__(self, title, description="", config=None, data_cb=None):
+    def __init__(self, title, description="", config=None, data_cb=None,
+        location=None, network_type=None, connection_type=None):
         self.title = title
         self.description = description
         self._config = config
         self._data_cb = data_cb
+        self._location = location
+        self._network_type = network_type
+        self._connection_type = connection_type
 
     def _start_test(self):
         raise RunnerError(self.title, "No _start_test() function implemented.")

--- a/murakami/runners/dash.py
+++ b/murakami/runners/dash.py
@@ -13,12 +13,16 @@ logger = logging.getLogger(__name__)
 
 class DashClient(MurakamiRunner):
     """Run Dash tests."""
-    def __init__(self, config=None, data_cb=None):
+    def __init__(self, config=None, data_cb=None,
+        location=None, network_type=None, connection_type=None):
         super().__init__(
             title="DASH",
             description="The Neubot DASH network test.",
             config=config,
             data_cb=data_cb,
+            location=location,
+            network_type=network_type,
+            connection_type=connection_type
         )
 
     @staticmethod

--- a/murakami/runners/dash.py
+++ b/murakami/runners/dash.py
@@ -33,10 +33,10 @@ class DashClient(MurakamiRunner):
                                     check=True,
                                     text=True,
                                     capture_output=True)
-            reader = jsonlines.Reader(output.stdout.splitlines())
             logger.info("Dash test complete.")
+            # TODO: write parser. Only print the last line for now.
+            return output.stdout.splitlines()[-1]
         else:
             raise RunnerError(
                 "dash",
                 "Executable dash-client does not exist, please install DASH.")
-        return [*reader.iter(skip_empty=True, skip_invalid=True)]

--- a/murakami/runners/ndt5.py
+++ b/murakami/runners/ndt5.py
@@ -2,8 +2,8 @@ import logging
 import shutil
 import subprocess
 import uuid
-
-import jsonlines
+import datetime
+import json
 
 from murakami.errors import RunnerError
 from murakami.runner import MurakamiRunner
@@ -40,18 +40,81 @@ class Ndt5Client(MurakamiRunner):
                 if insecure:
                     cmdargs.append('--insecure')
 
-
+            starttime = datetime.datetime.utcnow()
             output = subprocess.run(
                 cmdargs,
-                check=True,
                 text=True,
                 capture_output=True,
             )
-            reader = jsonlines.Reader(output.stdout.splitlines())
-            logger.info("NDT5 test complete.")
+            endtime = datetime.datetime.utcnow()
+
+            murakami_output = {
+                'TestName': "ndt5",
+                'TestStartTime': starttime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
+                'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
+                'MurakamiLocation': self._location,
+                'MurakamiConnectionType': self._connection_type,
+                'MurakamiNetworkType': self._network_type
+            }
+
+            if output.returncode == 0:
+                # Parse ndt5 summary.
+                summary = {}
+                try:
+                    summary = json.loads(output.stdout)
+                except json.JSONDecodeError:
+                    raise RunnerError(
+                        'ndt5-client',
+                        'ndt5-client did not return a valid JSON summary.')
+
+                logger.info("ndt5 test completed successfully.")
+
+                # Parse ndt7-client-go's summary JSON and generate Murakami's
+                # output format.
+                download = summary.get('Download')
+                upload = summary.get('Upload')
+                retrans = summary.get('DownloadRetrans')
+                min_rtt = summary.get('MinRTT')
+
+                murakami_output['ServerName'] = summary.get('ServerFQDN')
+                murakami_output['ServerIP'] = summary.get('ServerIP')
+                murakami_output['ClientIP'] = summary.get('ClientIP')
+                murakami_output['DownloadUUID'] = summary.get('DownloadUUID')
+                if download is not None:
+                    murakami_output['DownloadValue'] = download.get('Value')
+                    murakami_output['DownloadUnit'] = download.get('Unit')
+                if upload is not None:
+                    murakami_output['UploadValue'] = upload.get('Value')
+                    murakami_output['UploadUnit'] = upload.get('Unit')
+                if retrans is not None:
+                    murakami_output['DownloadRetransValue'] = retrans.get('Value')
+                    murakami_output['DownloadRetransUnit'] = retrans.get('Unit')
+                if min_rtt is not None:
+                    murakami_output['MinRTTValue'] = min_rtt.get('Value')
+                    murakami_output['MinRTTUnit'] = min_rtt.get('Unit')
+            else:
+                logger.warn("ndt5 test completed with errors.")
+
+                # Consider any output as 'TestError'.
+                murakami_output['TestError'] = output.stdout
+
+                # All the other fields are set to None (which will become null
+                # in the JSON.)
+                murakami_output['ServerName'] = None
+                murakami_output['ServerIP'] = None
+                murakami_output['ClientIP'] = None
+                murakami_output['DownloadUUID'] = None
+                murakami_output['DownloadValue'] = None
+                murakami_output['DownloadUnit'] = None
+                murakami_output['UploadValue'] = None
+                murakami_output['UploadUnit'] = None
+                murakami_output['DownloadRetransValue'] = None
+                murakami_output['DownloadRetransUnit'] = None
+                murakami_output['MinRTTValue'] = None
+                murakami_output['MinRTTUnit'] = None
+            return json.dumps(murakami_output)
         else:
             raise RunnerError(
                 "ndt5-client",
                 "Executable ndt5-client does not exist, please install ndt5-client-go.",
             )
-        return [*reader.iter(skip_empty=True, skip_invalid=True)]

--- a/murakami/runners/ndt5.py
+++ b/murakami/runners/ndt5.py
@@ -13,12 +13,16 @@ logger = logging.getLogger(__name__)
 
 class Ndt5Client(MurakamiRunner):
     """Run NDT5 test."""
-    def __init__(self, config=None, data_cb=None):
+    def __init__(self, config=None, data_cb=None,
+        location=None, network_type=None, connection_type=None):
         super().__init__(
             title="ndt5",
             description="The Network Diagnostic Tool v5 test.",
             config=config,
             data_cb=data_cb,
+            location=location,
+            network_type=network_type,
+            connection_type=connection_type
         )
 
     def _start_test(self):

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -57,10 +57,9 @@ class Ndt7Client(MurakamiRunner):
                 'MurakamiNetworkType': self._network_type
             }
 
-             # Parse ndt7 summary.
-            summary = {}
-
             if output.returncode == 0:
+                # Parse ndt7 summary.
+                summary = {}
                 try:
                     summary = json.loads(output.stdout)
                 except json.JSONDecodeError:

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -2,8 +2,8 @@ import logging
 import shutil
 import subprocess
 import uuid
-
-import jsonlines
+import json
+import datetime 
 
 from murakami.errors import RunnerError
 from murakami.runner import MurakamiRunner
@@ -13,12 +13,16 @@ logger = logging.getLogger(__name__)
 
 class Ndt7Client(MurakamiRunner):
     """Run ndt7 test."""
-    def __init__(self, config=None, data_cb=None):
+    def __init__(self, config=None, data_cb=None,
+        location=None, network_type=None, connection_type=None):
         super().__init__(
             title="ndt7",
             description="The Network Diagnostic Tool v7 test.",
             config=config,
             data_cb=data_cb,
+            location=location,
+            network_type=network_type,
+            connection_type=connection_type
         )
 
     def _start_test(self):
@@ -36,17 +40,54 @@ class Ndt7Client(MurakamiRunner):
                 if insecure:
                     cmdargs.append('--insecure')
 
+            starttime = datetime.datetime.utcnow()
             output = subprocess.run(
                 cmdargs,
                 check=True,
                 text=True,
                 capture_output=True,
             )
-            reader = jsonlines.Reader(output.stdout.splitlines())
-            logger.info("NDT7 test complete.")
+            endtime = datetime.datetime.utcnow()
+
+            murakami_output = {
+                'TestName': "ndt7",
+                'TestStartTime': starttime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
+                'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
+                'MurakamiLocation': self._location,
+                'MurakamiConnectionType': self._connection_type,
+                'MurakamiNetworkType': self._network_type
+            }
+
+             # Parse ndt7 summary.
+            summary = {}
+            try:
+                summary = json.loads(output.stdout)
+            except json.JSONDecodeError:
+                raise RunnerError(
+                    'ndt7-client',
+                    'ndt7-client did not return a valid JSON summary.'
+                )
+
+            if output.returncode == 0:
+                logger.info("ndt7 test completed successfully.")
+                print("Summary: {}".format(summary))
+                murakami_output['ServerName'] = summary['Server']
+                murakami_output['ClientIP'] = summary['Client']
+                murakami_output['DownloadValue'] = summary['Download']['Value']
+                murakami_output['DownloadUnit'] = summary['Download']['Unit']
+                murakami_output['DownloadError'] = None
+                murakami_output['DownloadRetransValue'] = summary['DownloadRetrans']['Value']
+                murakami_output['DownloadRetransUnit'] = summary['DownloadRetrans']['Unit']
+                murakami_output['UploadValue'] = summary['Upload']['Value']
+                murakami_output['UploadUnit'] = summary['Upload']['Unit']
+                murakami_output['UploadError'] = None 
+                murakami_output['RTTValue'] = summary["RTT"]['Value']
+                murakami_output['RTTUnit'] = summary["RTT"]['Unit']
+            else:
+                logger.warn("ndt7 test failed: %s", output.stderr.splitlines())
+            return json.dumps(murakami_output)
         else:
             raise RunnerError(
                 "ndt7-client",
                 "Executable ndt7-client does not exist, please install ndt7-client-go.",
             )
-        return [*reader.iter(skip_empty=True, skip_invalid=True)]

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -43,7 +43,6 @@ class Ndt7Client(MurakamiRunner):
             starttime = datetime.datetime.utcnow()
             output = subprocess.run(
                 cmdargs,
-                check=True,
                 text=True,
                 capture_output=True,
             )
@@ -60,31 +59,76 @@ class Ndt7Client(MurakamiRunner):
 
              # Parse ndt7 summary.
             summary = {}
-            try:
-                summary = json.loads(output.stdout)
-            except json.JSONDecodeError:
-                raise RunnerError(
-                    'ndt7-client',
-                    'ndt7-client did not return a valid JSON summary.'
-                )
 
             if output.returncode == 0:
+                try:
+                    summary = json.loads(output.stdout)
+                except json.JSONDecodeError:
+                    raise RunnerError(
+                        'ndt7-client',
+                        'ndt7-client did not return a valid JSON summary.'
+                    )
                 logger.info("ndt7 test completed successfully.")
-                print("Summary: {}".format(summary))
-                murakami_output['ServerName'] = summary['Server']
-                murakami_output['ClientIP'] = summary['Client']
-                murakami_output['DownloadValue'] = summary['Download']['Value']
-                murakami_output['DownloadUnit'] = summary['Download']['Unit']
-                murakami_output['DownloadError'] = None
-                murakami_output['DownloadRetransValue'] = summary['DownloadRetrans']['Value']
-                murakami_output['DownloadRetransUnit'] = summary['DownloadRetrans']['Unit']
-                murakami_output['UploadValue'] = summary['Upload']['Value']
-                murakami_output['UploadUnit'] = summary['Upload']['Unit']
-                murakami_output['UploadError'] = None 
-                murakami_output['RTTValue'] = summary["RTT"]['Value']
-                murakami_output['RTTUnit'] = summary["RTT"]['Unit']
+
+                # Parse ndt7-client-go's summary JSON and generate Murakami's
+                # output format.
+                download = summary.get('Download')
+                upload = summary.get('Upload')
+                retrans = summary.get('DownloadRetrans')
+                rtt = summary.get('RTT')
+
+                murakami_output['ServerName'] = summary.get('ServerFQDN')
+                murakami_output['ServerIP'] = summary.get('ServerIP')
+                murakami_output['ClientIP'] = summary.get('ClientIP')
+                murakami_output['DownloadUUID'] = summary.get('DownloadUUID')
+                if download is not None:
+                    murakami_output['DownloadValue'] = download.get('Value')
+                    murakami_output['DownloadUnit'] = download.get('Unit')
+                    murakami_output['DownloadError'] = None
+                if upload is not None:
+                    murakami_output['UploadValue'] = upload.get('Value')
+                    murakami_output['UploadUnit'] = upload.get('Unit')
+                    murakami_output['UploadError'] = None 
+                if retrans is not None:
+                    murakami_output['DownloadRetransValue'] = retrans.get('Value')
+                    murakami_output['DownloadRetransUnit'] = retrans.get('Unit')
+                if rtt is not None:
+                    murakami_output['RTTValue'] = rtt.get('Value')
+                    murakami_output['RTTUnit'] = rtt.get('Unit')
             else:
-                logger.warn("ndt7 test failed: %s", output.stderr.splitlines())
+                logger.warn("ndt7 test completed with errors.")
+
+                # Parse error line(s) and generate summary with UploadError and
+                # DownloadError only, if available.
+                errors = output.stdout.splitlines()
+                for j in errors:
+                    try:
+                        message = json.loads(j)
+                        if message['Value']['Test'] == 'upload':
+                            murakami_output['UploadError'] = (
+                                message['Value']['Failure']
+                            )
+                        elif message['Value']['Test'] == 'download':
+                            murakami_output['DownloadError']= (
+                                message['Value']['Failure']
+                            )
+                    except Exception as exc:
+                        logger.error("Cannot parse error message: %s", exc)
+                
+                # All the other fields are set to None (which will become null
+                # in the JSON.)
+                murakami_output['ServerName'] = None
+                murakami_output['ServerIP'] = None
+                murakami_output['ClientIP'] = None
+                murakami_output['DownloadUUID'] = None
+                murakami_output['DownloadValue'] = None
+                murakami_output['DownloadUnit'] = None
+                murakami_output['UploadValue'] = None
+                murakami_output['UploadUnit'] = None
+                murakami_output['DownloadRetransValue'] = None
+                murakami_output['DownloadRetransUnit'] = None
+                murakami_output['RTTValue'] = None
+                murakami_output['RTTUnit'] = None
             return json.dumps(murakami_output)
         else:
             raise RunnerError(

--- a/murakami/runners/speedtest.py
+++ b/murakami/runners/speedtest.py
@@ -33,12 +33,12 @@ class SpeedtestClient(MurakamiRunner):
                                     check=True,
                                     text=True,
                                     capture_output=True)
-            reader = jsonlines.Reader(output.stdout.splitlines())
+
             logger.info("Speedtest multi-stream test complete.")
+
+            # TODO: write parser. Only print the last line for now.
+            return output.stdout.splitlines()[-1]
         else:
             raise RunnerError(
                 "speedtest",
                 "Executable does not exist, please install speedtest-cli.")
-        return [
-            *reader.iter(skip_empty=True, skip_invalid=True)
-        ]

--- a/murakami/runners/speedtest.py
+++ b/murakami/runners/speedtest.py
@@ -13,12 +13,16 @@ logger = logging.getLogger(__name__)
 
 class SpeedtestClient(MurakamiRunner):
     """Run Speedtest.net tests."""
-    def __init__(self, config=None, data_cb=None):
+    def __init__(self, config=None, data_cb=None,
+        location=None, network_type=None, connection_type=None):
         super().__init__(
             title="Speedtest-cli-multi-stream",
             description="The Speedtest.net multi-stream test (https://github.com/sivel/speedtest-cli).",
             config=config,
             data_cb=data_cb,
+            location=location,
+            network_type=network_type,
+            connection_type=connection_type
         )
 
     @staticmethod

--- a/murakami/runners/speedtestsingle.py
+++ b/murakami/runners/speedtestsingle.py
@@ -13,12 +13,16 @@ logger = logging.getLogger(__name__)
 
 class SpeedtestSingleClient(MurakamiRunner):
     """Run Speedtest.net tests."""
-    def __init__(self, config=None, data_cb=None):
+    def __init__(self, config=None, data_cb=None,
+        location=None, network_type=None, connection_type=None):
         super().__init__(
             title="Speedtest-cli-single-stream",
             description="The Speedtest.net test (https://github.com/sivel/speedtest-cli).",
             config=config,
             data_cb=data_cb,
+            location=location,
+            network_type=network_type,
+            connection_type=connection_type
         )
 
     @staticmethod

--- a/murakami/runners/speedtestsingle.py
+++ b/murakami/runners/speedtestsingle.py
@@ -33,12 +33,12 @@ class SpeedtestSingleClient(MurakamiRunner):
                                     check=True,
                                     text=True,
                                     capture_output=True)
-            reader = jsonlines.Reader(output.stdout.splitlines())
-            logger.info("Speedtest single stream test complete.")
+
+            logger.info("Speedtest single-stream test complete.")
+
+            # TODO: write parser. Only print the last line for now.
+            return output.stdout.splitlines()[-1]
         else:
             raise RunnerError(
                 "speedtest",
                 "Executable does not exist, please install speedtest-cli.")
-        return [
-            *reader.iter(skip_empty=True, skip_invalid=True)
-        ]

--- a/murakami/server.py
+++ b/murakami/server.py
@@ -130,6 +130,9 @@ class MurakamiServer:
             self._runners[entry_point.name] = entry_point.load()(
                 config=self._config["tests"][entry_point.name],
                 data_cb=self._call_exporters,
+                location=self._location,
+                network_type=self._network_type,
+                connection_type=self._connection_type
             )
 
         # Start webthings server if enabled


### PR DESCRIPTION
This PR adds parsers for the ndt5 and ndt7 Go clients. It emits output following the schema we've discussed, including error handling.

A subsequent PR will also output the correct format for the `speedtest-cli` test. For now, it only saves the last line in the test output (which happens to be a JSON at least, even if not in the format we want.)

For the DASH client, we're waiting on upstream changes.