### PR TITLE
Fix Dockerfile + ndt7-client invocation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,10 @@ RUN go get github.com/m-lab/ndt7-client-go/cmd/ndt7-client
 RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 
 # Murakami image
-FROM python:3-alpine3.10
-RUN apk update && apk upgrade
+FROM python:3.7-stretch
 # Install dependencies and speedtest-cli
-RUN apk add git libgcc gcc libc-dev libffi-dev libressl-dev speedtest-cli make
+RUN apt-get update
+RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev speedtest-cli make
 RUN pip install 'poetry==0.12.17'
 
 WORKDIR /murakami

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,10 +6,10 @@ RUN go get github.com/m-lab/ndt7-client-go/cmd/ndt7-client
 RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 
 # Murakami image
-FROM balenalib/%%BALENA_MACHINE_NAME%%-alpine-python:3.7-edge
-RUN apk update && apk upgrade
+FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:3.7-buster
 # Install dependencies and speedtest-cli
-RUN apk add git libgcc gcc libc-dev libffi-dev libressl-dev speedtest-cli make
+RUN apt-get update
+RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev speedtest-cli make
 RUN pip install 'poetry==0.12.17'
 
 WORKDIR /murakami

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -35,7 +35,7 @@ class Ndt7Client(MurakamiRunner):
             ]
 
             if "host" in self._config:
-                cmdargs.append(self._config['host'])
+                cmdargs.append("-server=" + self._config['host'])
                 insecure = self._config.get('insecure', True)
                 if insecure:
                     cmdargs.append('--insecure')


### PR DESCRIPTION
These changes fix a build issue we're seeing with balenalib's alpine base image. It looks like the latest release(s) might be broken -- at least for the odroid-c1, I haven't tested them all.

However, the Debian buster base image seems perfectly fine. To avoid using two different distributions in the Balena vs standalone case, I've switched to debian in both Dockerfiles.

The change to the ndt7 runner is unrelated and fixes an issue with the invocation of the client when a `host` is specified in the murakami config file. The server's hostname was being passed as a positional argument rather than as a value for the `-server` flag, which does not work.