### PR TITLE
Change output field names

### DIFF
--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -74,7 +74,7 @@ class Ndt7Client(MurakamiRunner):
                 download = summary.get('Download')
                 upload = summary.get('Upload')
                 retrans = summary.get('DownloadRetrans')
-                rtt = summary.get('RTT')
+                minrtt = summary.get('MinRTT')
 
                 murakami_output['ServerName'] = summary.get('ServerFQDN')
                 murakami_output['ServerIP'] = summary.get('ServerIP')
@@ -91,9 +91,9 @@ class Ndt7Client(MurakamiRunner):
                 if retrans is not None:
                     murakami_output['DownloadRetransValue'] = retrans.get('Value')
                     murakami_output['DownloadRetransUnit'] = retrans.get('Unit')
-                if rtt is not None:
-                    murakami_output['MinRTTValue'] = rtt.get('Value')
-                    murakami_output['MinRTTUnit'] = rtt.get('Unit')
+                if minrtt is not None:
+                    murakami_output['MinRTTValue'] = minrtt.get('Value')
+                    murakami_output['MinRTTUnit'] = minrtt.get('Unit')
             else:
                 logger.warn("ndt7 test completed with errors.")
 

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 import uuid
 import json
-import datetime 
+import datetime
 
 from murakami.errors import RunnerError
 from murakami.runner import MurakamiRunner
@@ -87,13 +87,13 @@ class Ndt7Client(MurakamiRunner):
                 if upload is not None:
                     murakami_output['UploadValue'] = upload.get('Value')
                     murakami_output['UploadUnit'] = upload.get('Unit')
-                    murakami_output['UploadError'] = None 
+                    murakami_output['UploadError'] = None
                 if retrans is not None:
                     murakami_output['DownloadRetransValue'] = retrans.get('Value')
                     murakami_output['DownloadRetransUnit'] = retrans.get('Unit')
                 if rtt is not None:
-                    murakami_output['RTTValue'] = rtt.get('Value')
-                    murakami_output['RTTUnit'] = rtt.get('Unit')
+                    murakami_output['MinRTTValue'] = rtt.get('Value')
+                    murakami_output['MinRTTUnit'] = rtt.get('Unit')
             else:
                 logger.warn("ndt7 test completed with errors.")
 
@@ -113,7 +113,7 @@ class Ndt7Client(MurakamiRunner):
                             )
                     except Exception as exc:
                         logger.error("Cannot parse error message: %s", exc)
-                
+
                 # All the other fields are set to None (which will become null
                 # in the JSON.)
                 murakami_output['ServerName'] = None

--- a/murakami/runners/speedtest.py
+++ b/murakami/runners/speedtest.py
@@ -49,7 +49,7 @@ class SpeedtestClient(MurakamiRunner):
             murakami_output['UploadValue'] = summary.get('upload')
             murakami_output['UploadUnit'] = 'Bit/s'
             murakami_output['Ping'] = summary.get('ping')
-            murakami_output['PingUnits'] = 'ms'
+            murakami_output['PingUnit'] = 'ms'
             murakami_output['BytesSent'] = summary.get('bytes_sent')
             murakami_output['BytesReceived'] = summary.get('bytes_received')
             murakami_output['Share'] = summary.get('share')
@@ -70,7 +70,7 @@ class SpeedtestClient(MurakamiRunner):
                 murakami_output['ServerHost'] = server.get('host')
                 murakami_output['ServerDistance'] = server.get('d')
                 murakami_output['ServerLatency'] = server.get('latency')
-                murakami_output['ServerLatencyUnits'] = 'ms'
+                murakami_output['ServerLatencyUnit'] = 'ms'
 
             if client is not None:
                 murakami_output['ClientIP'] = client.get('ip')
@@ -108,7 +108,7 @@ class SpeedtestClient(MurakamiRunner):
             murakami_output['ServerHost'] = None
             murakami_output['ServerDistance'] = None
             murakami_output['ServerLatency'] = None
-            murakami_output['ServerLatencyUnits'] = None
+            murakami_output['ServerLatencyUnit'] = None
             murakami_output['ClientIP'] = None
             murakami_output['ClientLat'] = None
             murakami_output['ClientLon'] = None

--- a/murakami/runners/speedtest.py
+++ b/murakami/runners/speedtest.py
@@ -44,10 +44,10 @@ class SpeedtestClient(MurakamiRunner):
             summary = json.loads(output.stdout)
 
             murakami_output = {}
-            murakami_output['Download'] = summary.get('download')
-            murakami_output['DownloadUnits'] = 'Bit/s'
-            murakami_output['Upload'] = summary.get('upload')
-            murakami_output['UploadUnits'] = 'Bit/s'
+            murakami_output['DownloadValue'] = summary.get('download')
+            murakami_output['DownloadUnit'] = 'Bit/s'
+            murakami_output['UploadValue'] = summary.get('upload')
+            murakami_output['UploadUnit'] = 'Bit/s'
             murakami_output['Ping'] = summary.get('ping')
             murakami_output['PingUnits'] = 'ms'
             murakami_output['BytesSent'] = summary.get('bytes_sent')
@@ -89,10 +89,10 @@ class SpeedtestClient(MurakamiRunner):
             # Set TestError and every other field to None.
             murakami_output['TestError'] = output.stderr
 
-            murakami_output['Download'] = None
-            murakami_output['DownloadUnits'] = None
-            murakami_output['Upload'] = None
-            murakami_output['UploadUnits'] = None
+            murakami_output['DownloadValue'] = None
+            murakami_output['DownloadUnit'] = None
+            murakami_output['UploadValue'] = None
+            murakami_output['UploadUnit'] = None
             murakami_output['BytesSent'] = None
             murakami_output['BytesReceived'] = None
             murakami_output['Share'] = None


### PR DESCRIPTION
Updates speedtest-cli's output fields and uses MinRTT instead of RTT for ndt7-client.