### PR TITLE
Add device_id and MURAKAMI_SETTINGS_DEVICE_ID

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,4 +27,7 @@ RUN poetry config settings.virtualenvs.create false \
 # Add binaries' path to PATH.
 ENV PATH="/murakami/bin:${PATH}"
 
+# Set the DEVICE_ID to the BALENA_DEVICE_ID.
+ENV MURAKAMI_SETTINGS_DEVICE_ID="$BALENA_DEVICE_ID"
+
 ENTRYPOINT [ "murakami", "-d", "/data/config.json" ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,7 +27,4 @@ RUN poetry config settings.virtualenvs.create false \
 # Add binaries' path to PATH.
 ENV PATH="/murakami/bin:${PATH}"
 
-# Set the DEVICE_ID to the BALENA_DEVICE_ID.
-ENV MURAKAMI_SETTINGS_DEVICE_ID="$BALENA_DEVICE_ID"
-
 ENTRYPOINT [ "murakami", "-d", "/data/config.json" ]

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -44,7 +44,7 @@ def load_env():
 def default_device_id():
     """Return the value of the environment variable BALENA_DEVICE_ID if set, or
     an empty string."""
-    return os.environ.get('BALENA_DEVICE_ID', "")
+    return os.environ.get('BALENA_DEVICE_UUID', "")
 
 class TomlConfigFileParser(configargparse.ConfigFileParser):
     """

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -174,7 +174,13 @@ def main():
         "--connection-type",
         default=None,
         dest="connection_type",
-        help="Connection this associated with this node (default: '').",
+        help="Connection associated with this node (default: '').",
+    )
+    parser.add(
+        "--device-id",
+        default="",
+        dest="device_id",
+        help="Unique identifier for the current Murakami device (default: '').",
     )
     settings = parser.parse_args()
 
@@ -190,6 +196,8 @@ def main():
         state = livejson.File(settings.dynamic, pretty=True)
         config = ChainMap(state, config)
 
+    print(settings.connection_type)
+    print(config)
     server = MurakamiServer(
         port=settings.port,
         hostname=settings.hostname,
@@ -202,6 +210,7 @@ def main():
         location=settings.location,
         network_type=settings.network_type,
         connection_type=settings.connection_type,
+        device_id=settings.device_id,
         config=config,
     )
 

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -196,8 +196,6 @@ def main():
         state = livejson.File(settings.dynamic, pretty=True)
         config = ChainMap(state, config)
 
-    print(settings.connection_type)
-    print(config)
     server = MurakamiServer(
         port=settings.port,
         hostname=settings.hostname,

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -41,6 +41,10 @@ def load_env():
         recurse(sec, v, acc)
     return acc
 
+def default_device_id():
+    """Return the value of the environment variable BALENA_DEVICE_ID if set, or
+    an empty string."""
+    return os.environ.get('BALENA_DEVICE_ID', "")
 
 class TomlConfigFileParser(configargparse.ConfigFileParser):
     """
@@ -178,7 +182,7 @@ def main():
     )
     parser.add(
         "--device-id",
-        default="",
+        default=default_device_id(),
         dest="device_id",
         help="Unique identifier for the current Murakami device (default: '').",
     )

--- a/murakami/runner.py
+++ b/murakami/runner.py
@@ -26,14 +26,16 @@ class MurakamiRunner:
     * `data_cb`: The callback function that receives the test results
     """
     def __init__(self, title, description="", config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         self.title = title
         self.description = description
         self._config = config
         self._data_cb = data_cb
         self._location = location
         self._network_type = network_type
-        self._connection_type = connection_type
+        self._connection_type = connection_type,
+        self._device_id = device_id
 
     def _start_test(self):
         raise RunnerError(self.title, "No _start_test() function implemented.")

--- a/murakami/runner.py
+++ b/murakami/runner.py
@@ -34,7 +34,7 @@ class MurakamiRunner:
         self._data_cb = data_cb
         self._location = location
         self._network_type = network_type
-        self._connection_type = connection_type,
+        self._connection_type = connection_type
         self._device_id = device_id
 
     def _start_test(self):

--- a/murakami/runners/dash.py
+++ b/murakami/runners/dash.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class DashClient(MurakamiRunner):
     """Run Dash tests."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="DASH",
             description="The Neubot DASH network test.",
@@ -22,7 +23,8 @@ class DashClient(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id,
         )
 
     @staticmethod

--- a/murakami/runners/ndt5.py
+++ b/murakami/runners/ndt5.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class Ndt5Client(MurakamiRunner):
     """Run NDT5 test."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="ndt5",
             description="The Network Diagnostic Tool v5 test.",
@@ -22,7 +23,8 @@ class Ndt5Client(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id
         )
 
     def _start_test(self):
@@ -54,7 +56,8 @@ class Ndt5Client(MurakamiRunner):
                 'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'MurakamiLocation': self._location,
                 'MurakamiConnectionType': self._connection_type,
-                'MurakamiNetworkType': self._network_type
+                'MurakamiNetworkType': self._network_type,
+                'MurakamiDeviceID': self._device_id,
             }
 
             if output.returncode == 0:

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class Ndt7Client(MurakamiRunner):
     """Run ndt7 test."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="ndt7",
             description="The Network Diagnostic Tool v7 test.",
@@ -22,7 +23,8 @@ class Ndt7Client(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id
         )
 
     def _start_test(self):
@@ -54,7 +56,8 @@ class Ndt7Client(MurakamiRunner):
                 'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'MurakamiLocation': self._location,
                 'MurakamiConnectionType': self._connection_type,
-                'MurakamiNetworkType': self._network_type
+                'MurakamiNetworkType': self._network_type,
+                'MurakamiDeviceID': self._device_id,
             }
 
             if output.returncode == 0:

--- a/murakami/runners/speedtest.py
+++ b/murakami/runners/speedtest.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class SpeedtestClient(MurakamiRunner):
     """Run Speedtest.net tests."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="Speedtest-cli-multi-stream",
             description="The Speedtest.net multi-stream test (https://github.com/sivel/speedtest-cli).",
@@ -22,7 +23,8 @@ class SpeedtestClient(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id
         )
 
     @staticmethod
@@ -136,7 +138,8 @@ class SpeedtestClient(MurakamiRunner):
                 'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'MurakamiLocation': self._location,
                 'MurakamiConnectionType': self._connection_type,
-                'MurakamiNetworkType': self._network_type
+                'MurakamiNetworkType': self._network_type,
+                'MurakamiDeviceID': self._device_id,
             }
 
             murakami_output.update(self._parse_summary(output))

--- a/murakami/runners/speedtestsingle.py
+++ b/murakami/runners/speedtestsingle.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 class SpeedtestSingleClient(MurakamiRunner):
     """Run Speedtest.net tests."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="Speedtest-cli-single-stream",
             description="The Speedtest.net test (https://github.com/sivel/speedtest-cli).",
@@ -23,7 +24,8 @@ class SpeedtestSingleClient(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id
         )
 
     def _start_test(self):
@@ -42,7 +44,8 @@ class SpeedtestSingleClient(MurakamiRunner):
                 'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'MurakamiLocation': self._location,
                 'MurakamiConnectionType': self._connection_type,
-                'MurakamiNetworkType': self._network_type
+                'MurakamiNetworkType': self._network_type,
+                'MurakamiDeviceID': self._device_id,
             }
 
             murakami_output.update(SpeedtestClient._parse_summary(output))

--- a/murakami/server.py
+++ b/murakami/server.py
@@ -78,6 +78,7 @@ class MurakamiServer:
             location=None,
             network_type=None,
             connection_type=None,
+            device_id=None,
             config=None,
     ):
         self._runners = {}
@@ -97,6 +98,7 @@ class MurakamiServer:
         self._location = location
         self._network_type = network_type
         self._connection_type = connection_type
+        self._device_id = device_id
         self._config = config
 
     def _call_runners(self):
@@ -132,7 +134,8 @@ class MurakamiServer:
                 data_cb=self._call_exporters,
                 location=self._location,
                 network_type=self._network_type,
-                connection_type=self._connection_type
+                connection_type=self._connection_type,
+                device_id=self._device_id,
             )
 
         # Start webthings server if enabled


### PR DESCRIPTION
This PR adds the `--device-id` command line flag and the corresponding `MURAKAMI_SETTINGS_DEVICE_ID` environment variable. 

This field is saved in each test runner's output as `"MurakamiDeviceID": "value"`.

Please note that even if this is testable as-is, it will save the right value in the `.jsonl` only after https://github.com/m-lab/murakami/pull/62 has been merged, since reading the env variables is affected by that bug.