### PR TITLE
Add ndt5/ndt7 formats to convert.py

### DIFF
--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -29,7 +29,7 @@ class ConvertException(Exception):
 
     def __str__(self):
         if self.message:
-            return "ConvertException, {}".format(self.message)
+            return self.message
         else:
             return "ConvertException"
 
@@ -161,6 +161,12 @@ def import_ndt7(path):
         if data.get("TestName") != "ndt7":
             raise ConvertException("{}: Invalid ndt7 output file."
                 .format(path))
+
+        # Check this test completed without errors.
+        if data.get('TestError') is not None:
+            raise ConvertException(
+                "{}: test did not complete successfully, skipping."
+                    .format(path))
         return data
 
 tests = {

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -262,8 +262,8 @@ def main():
         importer = tests.get(settings.test, DEFAULT_TEST)
         try:
             contents = importer(path)
-        except ConvertException as ex:
-            print(ex.message)
+        except Exception as ex:
+            print(ex)
             continue
 
         if settings.pattern:


### PR DESCRIPTION
This adds two new test types, `-t ndt5` and `-t ndt7` to read the new ndt5/ndt7 test output files from Murakami.

e.g. to process all the ndt5 output files under `/tmp/`:
```
$ poetry run murakami-convert -t ndt5 -o test.csv /tmp/ndt5-*
Converting /tmp/ndt5-Corciano-home-wifi-2020-05-26T12:08:46.998838.jsonl...
Converting /tmp/ndt5-Corciano-home-wifi-2020-05-26T12:15:23.516439.jsonl...
Converting /tmp/ndt5-Corciano-home-wifi-2020-05-26T12:14:28.759458.jsonl...
/tmp/ndt5-Corciano-home-wifi-2020-05-26T12:14:28.759458.jsonl: test did not complete successfully, skipping.
Converting /tmp/ndt5-Corciano-home-wifi-2020-05-26T12:17:49.175471.jsonl...

$ cat test.csv 
"TestName","TestStartTime","TestEndTime","MurakamiLocation","MurakamiConnectionType","MurakamiNetworkType","MurakamiDeviceID","ServerName","ServerIP","ClientIP","DownloadUUID","DownloadValue","DownloadUnit","UploadValue","UploadUnit","DownloadRetransValue","DownloadRetransUnit","MinRTTValue","MinRTTUnit"
"ndt5","2020-05-26T12:08:46.999623","2020-05-26T12:09:08.058535","Corciano","['wifi']","home","","ndt-iupui-mlab3-mil04.mlab-oti.measurement-lab.org","213.242.77.165","93.188.100.10","ndt-xhndq_1589319099_00000000000D9D4B",340.67130031395976,"Mbit/s",43.963,"Mbit/s",0.009804904195191675,"%",20.975,"ms"
"ndt5","2020-05-26T12:15:23.516702","2020-05-26T12:15:44.360702","Corciano","['wifi']","home","","ndt-iupui-mlab2-mil05.mlab-oti.measurement-lab.org","195.89.147.24","93.188.100.10","ndt-g4ppq_1589309289_00000000000DDD26",223.0269863017354,"Mbit/s",36.005,"Mbit/s",0.008779511351908178,"%",31.01,"ms"
"ndt5","2020-05-26T12:17:49.176577","2020-05-26T12:18:09.981059","Corciano","wifi","home","","ndt-iupui-mlab2-mil05.mlab-oti.measurement-lab.org","195.89.147.24","93.188.100.10","ndt-g4ppq_1589309289_00000000000DDDBF",246.6801359867788,"Mbit/s",29.138,"Mbit/s",0.007936274928332326,"%",30.972,"ms"
```

Closes https://github.com/m-lab/murakami/issues/55.