### PR TITLE
Implement a basic HTTP exporter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Build ndt7, ndt5 and dash Go clients.
 FROM golang:1.13.10-buster AS build
-RUN apt install -y git
+RUN apt-get update
+RUN apt-get install -y git
 RUN go get github.com/m-lab/dash/cmd/dash-client
 RUN go get github.com/m-lab/ndt7-client-go/cmd/ndt7-client
 RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
@@ -12,7 +13,6 @@ RUN apt-get update
 RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make
 RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.2#egg=speedtest-cli
 RUN pip install 'poetry==0.12.17'
-
 
 WORKDIR /murakami
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 FROM python:3.7-buster
 # Install dependencies and speedtest-cli
 RUN apt-get update
-RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev speedtest-cli make
+RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make
+RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.2#egg=speedtest-cli
 RUN pip install 'poetry==0.12.17'
+
 
 WORKDIR /murakami
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,4 +27,7 @@ RUN poetry config settings.virtualenvs.create false \
 # Add binaries' path to PATH.
 ENV PATH="/murakami/bin:${PATH}"
 
+# Set the DEVICE_ID to the BALENA_DEVICE_ID.
+ENV MURAKAMI_SETTINGS_DEVICE_ID="$BALENA_DEVICE_ID"
+
 ENTRYPOINT [ "murakami", "-d", "/data/config.json" ]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,7 +10,8 @@ RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:3.7-buster
 # Install dependencies and speedtest-cli
 RUN apt-get update
-RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev speedtest-cli make
+RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make
+RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.2#egg=speedtest-cli
 RUN pip install 'poetry==0.12.17'
 
 WORKDIR /murakami

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -27,7 +27,4 @@ RUN poetry config settings.virtualenvs.create false \
 # Add binaries' path to PATH.
 ENV PATH="/murakami/bin:${PATH}"
 
-# Set the DEVICE_ID to the BALENA_DEVICE_ID.
-ENV MURAKAMI_SETTINGS_DEVICE_ID="$BALENA_DEVICE_ID"
-
 ENTRYPOINT [ "murakami", "-d", "/data/config.json" ]

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Murakami supports Linux operating systems like Ubuntu, Debian, etc. Windows is n
 
 ## Murakami Configurations and Customization
 
-A Murkami container can be configured flexibly depending on the deployment scenario. If you simply run a Murakami container using M-Lab's pre-built images on Dockerhub, by default all tests are configured to run four times daily at randomized intervals, but with no data exporters enabled. This section focuses on which options can be configured using the file `murakami.toml` OR using environment variables.
+A Murakami container can be configured flexibly depending on the deployment scenario. If you simply run a Murakami container using M-Lab's pre-built images on Dockerhub, by default all tests are configured to run four times daily at randomized intervals, but with no data exporters enabled. This section focuses on which options can be configured using the file `murakami.toml` OR using environment variables.
 
 The Murakami container can be customized using:
 * environment variables on the command line when running docker (Standalone, Standalone Locally Managed)

--- a/docs/CONVERT-DATA.md
+++ b/docs/CONVERT-DATA.md
@@ -1,0 +1,31 @@
+# Converting Murakami Data to CSV
+
+When using the local, GCS, or SCP exporters that come with Murakami, each test result is saved as a single JSON file. JSON is a great format for machines to process data, but users may wish to analyze all collected data in other programs, so we've included a utility script in Murakami that converts the results for each supported test runner to CSV format.
+
+## Using the murakami-convert Utility Script
+
+In the main folder of the Murakami repo, you'll see `scripts/convert.py`. This Python utility script will convert test results from supported runners from JSON to CSV. Below we'll run through one example of how to use it.
+
+Download or navigate on the command line to the location where you've saved your test results. In our case, we are using the GCS exporter to push all test results to a common archive location. To convert these files to CSV, we first downloaded all the test results for a particular location from GCS to our local computer.
+
+Next, we can run the Murakami Docker container on our local computer, and mount the folder containing our test results inside it.
+
+`docker run -it --entrypoint /bin/bash --volume /path/to/test-results:/data/ measurementlab/murakami:latest`
+
+That command will pull the latest Murakami image from M-Lab's Dockerhub, and drop you into a terminal: `root@714d9de32802:/murakami#`
+
+You should then be able to see your test results: `root@714d9de32802:/murakami# ls -la /data/`
+
+Create a folder to save your converted CSV files: ``root@714d9de32802:/murakami# mkdir /data/csv`
+
+Now you can use `murakami-convert` to convert the results of each test runner. To review all the available script options, type: `murakami-convert --help`
+
+Below are examples converting the different supported test runners. Note that your filenames are likely different than our example, so you should adjust the last part of these commands to match the naming patterns of your files.
+
+* ndt5 - `root@714d9de32802:/murakami# murakami-convert -t ndt5 -r -o /data/csv/ndt5-egress.csv /data/ndt5*`
+* ndt7 - `root@714d9de32802:/murakami# murakami-convert -t ndt7 -r -o /data/csv/ndt7-egress.csv /data/ndt5*`
+* speedtest-cli single stream - `root@714d9de32802:/murakami# murakami-convert -t speedtest -r -o /data/csv/speedtest-cli-singlestream-egress.csv /data/speedtest-single*`
+* speedtest-cli multi stream - `root@714d9de32802:/murakami# murakami-convert -t speedtest -r -o /data/csv/speedtest-cli-multistream-egress.csv /data/speedtest-multi*`
+
+When you're done converting your files, exit the container. The CSVs should now be in the csv folder where you exported them.
+

--- a/murakami.toml.example
+++ b/murakami.toml.example
@@ -28,6 +28,11 @@ connection-type = "wired"
   service_account = "murakami-test-gcs@mlab-sandbox.iam.gserviceaccount.com"
   key = "/murakami/keys/murakami-gcs-serviceaccount.json"
 
+  [exporters.http]
+  type = "http"
+  enabled = true
+  url = "http://some-test-url/v1/upload"
+
 [tests]
 
   [tests.dash]

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -44,7 +44,7 @@ def load_env():
 def default_device_id():
     """Return the value of the environment variable BALENA_DEVICE_ID if set, or
     an empty string."""
-    return os.environ.get('BALENA_DEVICE_ID', "")
+    return os.environ.get('BALENA_DEVICE_UUID', "")
 
 class TomlConfigFileParser(configargparse.ConfigFileParser):
     """

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -174,7 +174,13 @@ def main():
         "--connection-type",
         default=None,
         dest="connection_type",
-        help="Connection this associated with this node (default: '').",
+        help="Connection associated with this node (default: '').",
+    )
+    parser.add(
+        "--device-id",
+        default="",
+        dest="device_id",
+        help="Unique identifier for the current Murakami device (default: '').",
     )
     settings = parser.parse_args()
 
@@ -190,6 +196,8 @@ def main():
         state = livejson.File(settings.dynamic, pretty=True)
         config = ChainMap(state, config)
 
+    print(settings.connection_type)
+    print(config)
     server = MurakamiServer(
         port=settings.port,
         hostname=settings.hostname,
@@ -202,6 +210,7 @@ def main():
         location=settings.location,
         network_type=settings.network_type,
         connection_type=settings.connection_type,
+        device_id=settings.device_id,
         config=config,
     )
 

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -196,8 +196,6 @@ def main():
         state = livejson.File(settings.dynamic, pretty=True)
         config = ChainMap(state, config)
 
-    print(settings.connection_type)
-    print(config)
     server = MurakamiServer(
         port=settings.port,
         hostname=settings.hostname,

--- a/murakami/__main__.py
+++ b/murakami/__main__.py
@@ -41,6 +41,10 @@ def load_env():
         recurse(sec, v, acc)
     return acc
 
+def default_device_id():
+    """Return the value of the environment variable BALENA_DEVICE_ID if set, or
+    an empty string."""
+    return os.environ.get('BALENA_DEVICE_ID', "")
 
 class TomlConfigFileParser(configargparse.ConfigFileParser):
     """
@@ -178,7 +182,7 @@ def main():
     )
     parser.add(
         "--device-id",
-        default="",
+        default=default_device_id(),
         dest="device_id",
         help="Unique identifier for the current Murakami device (default: '').",
     )

--- a/murakami/exporters/http.py
+++ b/murakami/exporters/http.py
@@ -31,6 +31,7 @@ class HTTPExporter(MurakamiExporter):
 
     def push(self, test_name="", data=None, timestamp=None):
         # Make a JSON payload with the expected format
+        data = json.loads(data)
         json_data = {
             'apiVersion': 1,
             'data': data

--- a/murakami/exporters/http.py
+++ b/murakami/exporters/http.py
@@ -11,13 +11,14 @@ logger = logging.getLogger(__name__)
 
 class HTTPExporter(MurakamiExporter):
     """This exporter sends data to an HTTP endpoint."""
+
     def __init__(
-            self,
-            name="",
-            location=None,
-            network_type=None,
-            connection_type=None,
-            config=None,
+        self,
+        name="",
+        location=None,
+        network_type=None,
+        connection_type=None,
+        config=None,
     ):
         super().__init__(
             name=name,
@@ -32,21 +33,18 @@ class HTTPExporter(MurakamiExporter):
     def push(self, test_name="", data=None, timestamp=None):
         # Make a JSON payload with the expected format
         data = json.loads(data)
-        json_data = {
-            'apiVersion': 1,
-            'data': data
-        }
+        data = {k: v for k, v in data.items() if v is not None}
+        json_data = {"apiVersion": 1, "data": data}
 
         # POST the payload.
-        resp = requests.post(self._url, data=json.dumps(json_data))
+        resp = requests.post(self._url, json=json_data)
+        logging.debug("Exporting data: {}".format(json.dumps(json_data)))
         if not resp.ok:
-            logger.error("Exporting to HTTP endpoint failed: {}".format(
-                resp.json()
-            ))
+            logger.error("Exporting to HTTP endpoint failed: {}".format(resp.json()))
             return False
-        logger.info("Test data successfully sent to {}. Response: {}"
-            .format(
-                self._url,
-                resp.json()
-            ))
+        logger.info(
+            "Test data successfully sent to {}. Response: {}".format(
+                self._url, resp.json()
+            )
+        )
         return True

--- a/murakami/exporters/http.py
+++ b/murakami/exporters/http.py
@@ -1,0 +1,44 @@
+import logging
+import os
+import json
+
+import requests
+
+from murakami.exporter import MurakamiExporter
+
+logger = logging.getLogger(__name__)
+
+
+class HTTPExporter(MurakamiExporter):
+    """This exporter sends data to an HTTP endpoint."""
+    def __init__(
+            self,
+            name="",
+            location=None,
+            network_type=None,
+            connection_type=None,
+            config=None,
+    ):
+        super().__init__(
+            name=name,
+            location=location,
+            network_type=network_type,
+            connection_type=connection_type,
+            config=config,
+        )
+        logging.debug(config)
+        self._url = config.get("url")
+
+    def push(self, test_name="", data=None, timestamp=None):
+        # Make a JSON payload with the expected format
+        json_data = {
+            'apiVersion': 1,
+            data: data
+        }
+
+        # POST the payload.
+        resp = requests.post(self._url, data=json.dumps(json_data))
+        if resp.status_code != 200:
+            logger.error("Exporting to HTTP endpoint failed: {}".format(
+                resp.text
+            ))

--- a/murakami/exporters/http.py
+++ b/murakami/exporters/http.py
@@ -33,12 +33,19 @@ class HTTPExporter(MurakamiExporter):
         # Make a JSON payload with the expected format
         json_data = {
             'apiVersion': 1,
-            data: data
+            'data': data
         }
 
         # POST the payload.
         resp = requests.post(self._url, data=json.dumps(json_data))
-        if resp.status_code != 200:
+        if not resp.ok:
             logger.error("Exporting to HTTP endpoint failed: {}".format(
-                resp.text
+                resp.json()
             ))
+            return False
+        logger.info("Test data successfully sent to {}. Response: {}"
+            .format(
+                self._url,
+                resp.json()
+            ))
+        return True

--- a/murakami/runner.py
+++ b/murakami/runner.py
@@ -26,14 +26,16 @@ class MurakamiRunner:
     * `data_cb`: The callback function that receives the test results
     """
     def __init__(self, title, description="", config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         self.title = title
         self.description = description
         self._config = config
         self._data_cb = data_cb
         self._location = location
         self._network_type = network_type
-        self._connection_type = connection_type
+        self._connection_type = connection_type,
+        self._device_id = device_id
 
     def _start_test(self):
         raise RunnerError(self.title, "No _start_test() function implemented.")

--- a/murakami/runner.py
+++ b/murakami/runner.py
@@ -34,7 +34,7 @@ class MurakamiRunner:
         self._data_cb = data_cb
         self._location = location
         self._network_type = network_type
-        self._connection_type = connection_type,
+        self._connection_type = connection_type
         self._device_id = device_id
 
     def _start_test(self):

--- a/murakami/runners/dash.py
+++ b/murakami/runners/dash.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class DashClient(MurakamiRunner):
     """Run Dash tests."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="DASH",
             description="The Neubot DASH network test.",
@@ -22,7 +23,8 @@ class DashClient(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id,
         )
 
     @staticmethod

--- a/murakami/runners/ndt5.py
+++ b/murakami/runners/ndt5.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class Ndt5Client(MurakamiRunner):
     """Run NDT5 test."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="ndt5",
             description="The Network Diagnostic Tool v5 test.",
@@ -22,7 +23,8 @@ class Ndt5Client(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id
         )
 
     def _start_test(self):
@@ -54,7 +56,8 @@ class Ndt5Client(MurakamiRunner):
                 'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'MurakamiLocation': self._location,
                 'MurakamiConnectionType': self._connection_type,
-                'MurakamiNetworkType': self._network_type
+                'MurakamiNetworkType': self._network_type,
+                'MurakamiDeviceID': self._device_id,
             }
 
             if output.returncode == 0:

--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class Ndt7Client(MurakamiRunner):
     """Run ndt7 test."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="ndt7",
             description="The Network Diagnostic Tool v7 test.",
@@ -22,7 +23,8 @@ class Ndt7Client(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id
         )
 
     def _start_test(self):
@@ -54,7 +56,8 @@ class Ndt7Client(MurakamiRunner):
                 'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'MurakamiLocation': self._location,
                 'MurakamiConnectionType': self._connection_type,
-                'MurakamiNetworkType': self._network_type
+                'MurakamiNetworkType': self._network_type,
+                'MurakamiDeviceID': self._device_id,
             }
 
             if output.returncode == 0:

--- a/murakami/runners/speedtest.py
+++ b/murakami/runners/speedtest.py
@@ -14,7 +14,8 @@ logger = logging.getLogger(__name__)
 class SpeedtestClient(MurakamiRunner):
     """Run Speedtest.net tests."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="Speedtest-cli-multi-stream",
             description="The Speedtest.net multi-stream test (https://github.com/sivel/speedtest-cli).",
@@ -22,7 +23,8 @@ class SpeedtestClient(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id
         )
 
     @staticmethod
@@ -136,7 +138,8 @@ class SpeedtestClient(MurakamiRunner):
                 'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'MurakamiLocation': self._location,
                 'MurakamiConnectionType': self._connection_type,
-                'MurakamiNetworkType': self._network_type
+                'MurakamiNetworkType': self._network_type,
+                'MurakamiDeviceID': self._device_id,
             }
 
             murakami_output.update(self._parse_summary(output))

--- a/murakami/runners/speedtestsingle.py
+++ b/murakami/runners/speedtestsingle.py
@@ -15,7 +15,8 @@ logger = logging.getLogger(__name__)
 class SpeedtestSingleClient(MurakamiRunner):
     """Run Speedtest.net tests."""
     def __init__(self, config=None, data_cb=None,
-        location=None, network_type=None, connection_type=None):
+        location=None, network_type=None, connection_type=None,
+        device_id=None):
         super().__init__(
             title="Speedtest-cli-single-stream",
             description="The Speedtest.net test (https://github.com/sivel/speedtest-cli).",
@@ -23,7 +24,8 @@ class SpeedtestSingleClient(MurakamiRunner):
             data_cb=data_cb,
             location=location,
             network_type=network_type,
-            connection_type=connection_type
+            connection_type=connection_type,
+            device_id=device_id
         )
 
     def _start_test(self):
@@ -42,7 +44,8 @@ class SpeedtestSingleClient(MurakamiRunner):
                 'TestEndTime': endtime.strftime('%Y-%m-%dT%H:%M:%S.%f'),
                 'MurakamiLocation': self._location,
                 'MurakamiConnectionType': self._connection_type,
-                'MurakamiNetworkType': self._network_type
+                'MurakamiNetworkType': self._network_type,
+                'MurakamiDeviceID': self._device_id,
             }
 
             murakami_output.update(SpeedtestClient._parse_summary(output))

--- a/murakami/server.py
+++ b/murakami/server.py
@@ -78,6 +78,7 @@ class MurakamiServer:
             location=None,
             network_type=None,
             connection_type=None,
+            device_id=None,
             config=None,
     ):
         self._runners = {}
@@ -97,6 +98,7 @@ class MurakamiServer:
         self._location = location
         self._network_type = network_type
         self._connection_type = connection_type
+        self._device_id = device_id
         self._config = config
 
     def _call_runners(self):
@@ -132,7 +134,8 @@ class MurakamiServer:
                 data_cb=self._call_exporters,
                 location=self._location,
                 network_type=self._network_type,
-                connection_type=self._connection_type
+                connection_type=self._connection_type,
+                device_id=self._device_id,
             )
 
         # Start webthings server if enabled

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ pytest-cov = "^2.8"
 "local" = "murakami.exporters.local:LocalExporter"
 "scp" = "murakami.exporters.scp:SCPExporter"
 "gcs" = "murakami.exporters.gcs:GCSExporter"
+"http" = "murakami.exporters.http:HTTPExporter"
 
 [tool.tox]
 legacy_tox_ini = """

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -29,7 +29,7 @@ class ConvertException(Exception):
 
     def __str__(self):
         if self.message:
-            return "ConvertException, {}".format(self.message)
+            return self.message
         else:
             return "ConvertException"
 
@@ -161,6 +161,12 @@ def import_ndt7(path):
         if data.get("TestName") != "ndt7":
             raise ConvertException("{}: Invalid ndt7 output file."
                 .format(path))
+
+        # Check this test completed without errors.
+        if data.get('TestError') is not None:
+            raise ConvertException(
+                "{}: test did not complete successfully, skipping."
+                    .format(path))
         return data
 
 tests = {

--- a/scripts/convert.py
+++ b/scripts/convert.py
@@ -262,8 +262,8 @@ def main():
         importer = tests.get(settings.test, DEFAULT_TEST)
         try:
             contents = importer(path)
-        except ConvertException as ex:
-            print(ex.message)
+        except Exception as ex:
+            print(ex)
             continue
 
         if settings.pattern:

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -1,0 +1,29 @@
+import time
+from unittest.mock import Mock, patch
+
+from murakami.exporters.http import HTTPExporter
+
+RESPONSE_SUCCESS_JSON = {
+    'status': 'success'
+}
+
+RESPONSE_FAILURE_JSON = {
+    'error': '<Error type>',
+    'message': '<Error message>'
+}
+
+@patch('requests.post')
+def test_push_response_ok(mock_post):
+    mock_post.return_value = Mock(ok=True)
+    mock_post.return_value.json.return_value = RESPONSE_SUCCESS_JSON
+
+    exporter = HTTPExporter("test", config={'url': 'http://testurl'})
+    assert exporter.push("ndt5", {'TestName': 'ndt5'}, time.time()) is True
+
+@patch('requests.post')
+def test_push_response_error(mock_post):
+    mock_post.return_value = Mock(ok=False)
+    mock_post.return_value.json.return_value = RESPONSE_FAILURE_JSON
+
+    exporter = HTTPExporter("test", config={'url': 'http://testurl'})
+    assert exporter.push("ndt5", {'TestName': 'ndt5'}, time.time()) is False

--- a/tests/test_http.py
+++ b/tests/test_http.py
@@ -18,7 +18,7 @@ def test_push_response_ok(mock_post):
     mock_post.return_value.json.return_value = RESPONSE_SUCCESS_JSON
 
     exporter = HTTPExporter("test", config={'url': 'http://testurl'})
-    assert exporter.push("ndt5", {'TestName': 'ndt5'}, time.time()) is True
+    assert exporter.push("ndt5", '{"TestName": "ndt5"}', time.time()) is True
 
 @patch('requests.post')
 def test_push_response_error(mock_post):
@@ -26,4 +26,4 @@ def test_push_response_error(mock_post):
     mock_post.return_value.json.return_value = RESPONSE_FAILURE_JSON
 
     exporter = HTTPExporter("test", config={'url': 'http://testurl'})
-    assert exporter.push("ndt5", {'TestName': 'ndt5'}, time.time()) is False
+    assert exporter.push("ndt5", '{"TestName": "ndt5"}', time.time()) is False


### PR DESCRIPTION
This PR adds a new exporter (`type="http"`) which sends the JSON output of a test to an HTTP endpoint via a POST request. 

The format of the JSON object is:
```
{
    "apiVersion": 1,
    "data": { <Murakami output JSON> }
}
```

It also includes some fairly basic unit tests for this exporter.

Since there is no authentication method on the upload service prototype yet, the only configuration parameter for this exporter type is `url`. E.g.
```
[exporters.http]
type = "http"
enabled = true
url = "http://some-url/api/v1/runs"
```