### PR TITLE
Get latest speedtest-cli release from git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 # Build ndt7, ndt5 and dash Go clients.
 FROM golang:1.13.10-buster AS build
-RUN apt install -y git
+RUN apt-get update
+RUN apt-get install -y git
 RUN go get github.com/m-lab/dash/cmd/dash-client
 RUN go get github.com/m-lab/ndt7-client-go/cmd/ndt7-client
 RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
@@ -12,7 +13,6 @@ RUN apt-get update
 RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make
 RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.2#egg=speedtest-cli
 RUN pip install 'poetry==0.12.17'
-
 
 WORKDIR /murakami
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,10 @@ RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 FROM python:3.7-buster
 # Install dependencies and speedtest-cli
 RUN apt-get update
-RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev speedtest-cli make
+RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make
+RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.2#egg=speedtest-cli
 RUN pip install 'poetry==0.12.17'
+
 
 WORKDIR /murakami
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,7 +10,8 @@ RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:3.7-buster
 # Install dependencies and speedtest-cli
 RUN apt-get update
-RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev speedtest-cli make
+RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make
+RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.2#egg=speedtest-cli
 RUN pip install 'poetry==0.12.17'
 
 WORKDIR /murakami


### PR DESCRIPTION
Using Debian Buster as base image means that the `speedtest-cli` in the repositories is an older version, not supporting `--single`. 

This change directly fetches a specific tag from git.

Closes https://github.com/m-lab/murakami/issues/66.