### PR TITLE
in ndt7 test runner, change --insecure to -no-verify

### DIFF
--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -40,7 +40,7 @@ class Ndt7Client(MurakamiRunner):
                 cmdargs.append("-server=" + self._config['host'])
                 insecure = self._config.get('insecure', True)
                 if insecure:
-                    cmdargs.append('--insecure')
+                    cmdargs.append('-no-verify')
 
             starttime = datetime.datetime.utcnow()
             output = subprocess.run(


### PR DESCRIPTION
This PR changes the flag from --insecure to -no-verify when a host value is supplied to the ndt7 test runner. 
The change has been tested with a self-hosted ndt-server and an env variable with the host ip and port. 