### PR TITLE
add rust and cargo, upgrade pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 FROM python:3.7-buster
 # Install dependencies and speedtest-cli
 RUN apt-get update
-RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make
+RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make rustc cargo
+RUN /usr/local/bin/python3.7 -m pip install --upgrade pip
 RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.3#egg=speedtest-cli
 RUN pip install 'poetry==1.1.7'
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,7 +11,8 @@ RUN go get github.com/m-lab/ndt5-client-go/cmd/ndt5-client
 FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:3.7-buster
 # Install dependencies and speedtest-cli
 RUN apt-get update
-RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make
+RUN apt-get install -y git gcc libc-dev libffi-dev libssl-dev make rustc cargo
+RUN /usr/local/bin/python3.7 -m pip install --upgrade pip
 RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.3#egg=speedtest-cli
 RUN pip install 'poetry==1.1.7'
 


### PR DESCRIPTION
Added these packages and upgrade pip command to resolve a build issue with Balena. 
poetry==1.1.7 build failed since the cryptography package couldn't be built under PEP 517. See error log below. This now builds on Balena, and we'll cross check travis.

```
[main]           =============================DEBUG ASSISTANCE=============================
[main]       error: [Errno 2] No such file or directory: 'cargo': 'cargo'
[main]       ----------------------------------------
[main]     
[main]       ERROR: Failed building wheel for cryptography
[main]     
[main]     Failed to build cryptography
[main]     ERROR: Could not build wheels for cryptography which use PEP 517 and cannot be installed directly
[main]     
[main]     WARNING: You are using pip version 21.0.1; however, version 21.2.4 is available.
[main]     You should consider upgrading via the '/usr/local/bin/python3.7 -m pip install --upgrade pip' command.
[main]     
[main]     Removing intermediate container 1759c33ca36b
[main]     The command '/bin/sh -c pip install 'poetry==1.1.7'' returned a non-zero code: 1
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/91)
<!-- Reviewable:end -->
