### PR TITLE
Add project setup utility scripts

### DIFF
--- a/utilities/bq_load_murakami.sh
+++ b/utilities/bq_load_murakami.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# This script is intended to be run daily using a scheduled job/cron,
+# and loads test results from the GCS bucket where Murakami devices are
+# exporting to tables in BigQuery.
+#
+# A service account or personal Google account running this script
+# requires these permissions in your project:  
+#  BigQuery Job User, BigQuery Data Editor, Storage Object Viewer
+
+# Set the variables below for your installation
+gcp_project="<gcp project>"
+gcs_bucket="<gcs bucket>/<path>"
+bq_dataset="<bigquery dataset>"
+bq_ndt7_table="ndt7"
+bq_ndt5_table="ndt5"
+bq_speedtest_table="speedtest"
+
+# Load data from yesterday in UTC
+loaddate=`date -d "$date - 1 day" +"%Y-%m-%d"`
+
+# NDT 7 loader
+
+for f in `gsutil ls gs://$gcs_bucket/ndt7*$loaddate*`
+do
+   bq load --source_format=NEWLINE_DELIMITED_JSON \
+   --project_id=$gcp_project $bq_dataset.$bq_ndt7_table $f \
+   schemas/ndt7Schema.json
+done
+
+# NDT 5 loader
+for f in `gsutil ls gs://$gcs_bucket/ndt5*$loaddate*`
+do
+   bq load --source_format=NEWLINE_DELIMITED_JSON \
+   --project_id=$gcp_project $bq_dataset.$bq_ndt5_table $f \
+   schemas/ndt5Schema.json
+done
+
+# Speedtest-cli loader
+for f in `gsutil ls gs://$gcs_bucket/speedtest-cli*$loaddate*`
+do
+   bq load --source_format=NEWLINE_DELIMITED_JSON \
+   --project_id=$gcp_project $bq_dataset.$bq_speedtest_table $f \
+   schemas/speedtestSchema.json
+done

--- a/utilities/bq_load_murakami.sh
+++ b/utilities/bq_load_murakami.sh
@@ -8,10 +8,11 @@
 # requires these permissions in your project:  
 #  BigQuery Job User, BigQuery Data Editor, Storage Object Viewer
 
-# Set the variables below for your installation
-gcp_project="<gcp project>"
-gcs_bucket="<gcs bucket>/<path>"
-bq_dataset="<bigquery dataset>"
+usage="$0 <project> <bucket> <dataset>"
+gcp_project=${1:?Please provide the GCP project: ${usage}}
+gcs_bucket=${2:?Please provide the GCS bucket: ${usage}}
+bq_dataset=${3:?Please provide the dataset name: ${usage}}
+
 bq_ndt7_table="ndt7"
 bq_ndt5_table="ndt5"
 bq_speedtest_table="speedtest"

--- a/utilities/schemas/locationsMetaSchema.json
+++ b/utilities/schemas/locationsMetaSchema.json
@@ -1,0 +1,140 @@
+[
+	{
+		"description": "Location Name - Top level name for this location.",
+		"mode": "NULLABLE",
+		"name": "LocName",
+		"type":"STRING"
+	},
+	{
+		"description": "Location Secondary Name - Additional name field to support locations with second level of named locations in a hierarchy, such as branch names for libraries.",
+		"mode": "NULLABLE",
+		"name": "LocSecondaryName",
+		"type":"STRING"
+	},
+	{
+		"description": "Location Tertiary Name - Additional name field to support locations with third level of named locations in a hierarchy.",
+		"mode": "NULLABLE",
+		"name": "LocTertiaryName",
+		"type":"STRING"
+	},
+	{
+		"description": "Country Name",
+		"mode": "NULLABLE",
+		"name": "CountryName",
+		"type":"STRING"
+	},
+	{
+		"description": "Country Code - 2 alphanumeric code within ISO3166 standard.",
+		"mode": "NULLABLE",
+		"name": "CountryCode",
+		"type":"STRING"
+	},
+	{
+		"description": "Timezone of this location. Example: America/New_York",
+		"mode": "NULLABLE",
+		"name": "TimeZone",
+		"type":"STRING"
+	},
+	{
+		"description": "Postal code of this location (if applicable)",
+		"mode": "NULLABLE",
+		"name": "PostalCode",
+		"type":"STRING"
+	},
+	{
+		"description": "Latitude & Longitude of this location. Format: latitude, longitude ",
+		"mode": "NULLABLE",
+		"name": "LatLon",
+		"type":"STRING"
+	},
+	{
+		"description": "Murakami Location - Should match a value for MURAKAMI_SETTINGS_LOCATION as defined in a measurement device's environment variables. See Murakami documentation for more details.",
+		"mode": "NULLABLE",
+		"name": "MurakamiLocation",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 1 Name - The name of this ISP as presented on terms of service, bill, or other. Can be different than ASN/AS Name.",
+		"mode": "NULLABLE",
+		"name": "Isp1Name",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 1 Type - If useful to measurement programs, use this field to classify different types of providers. Examples: Non-profit, Cooperative, State/City, Commercial Business ISP, Consumer ISP, Research & Education Network, Commercial Direct Transit.",
+		"mode": "NULLABLE",
+		"name": "Isp1Type",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 1 Access Media - Examples: Cable, DSL, Fiber, Satellite, etc.",
+		"mode": "NULLABLE",
+		"name": "Isp1AccessMedia",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 1 Connection Type - Should match a value for MURAKAMI_SETTINGS_CONNECTION_TYPE as defined in a measurement device's environment variables. See Murakami documentation for more details.",
+		"mode": "NULLABLE",
+		"name": "Isp1ConnectionType",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 1 Network Type - Should match a value for MURAKAMI_SETTINGS_NETWORK_TYPE as defined in a measurement device's environment variables. See Murakami documentation for more details.",
+		"mode": "NULLABLE",
+		"name": "Isp1NetworkType",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 1 ASN - The Autonomous System Number of the ISP providing service to this location. Lookup the ASN from a computer connected to this location by visiting: https://ipinfo.io ",
+		"mode": "NULLABLE",
+		"name": "Isp1ASN",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 1 AS Name - The Autonomous System Name of the ISP providing service to this location. Lookup the AS Name from a computer connected to this location by visiting: https://ipinfo.io ",
+		"mode": "NULLABLE",
+		"name": "Isp1ASName",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 Name - The name of this ISP as presented on terms of service, bill, or other. Can be different than ASN/AS Name.",
+		"mode": "NULLABLE",
+		"name": "Isp2Name",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 Type - If useful to measurement programs, use this field to classify different types of providers. Examples: Non-profit, Cooperative, State/City, Commercial Business ISP, Consumer ISP, Research & Education Network, Commercial Direct Transit.",
+		"mode": "NULLABLE",
+		"name": "Isp2Type",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 Access Media - Examples: Cable, DSL, Fiber, Satellite, etc.",
+		"mode": "NULLABLE",
+		"name": "Isp2AccessMedia",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 Connection Type - Should match a value for MURAKAMI_SETTINGS_CONNECTION_TYPE as defined in a measurement device's environment variables. See Murakami documentation for more details.",
+		"mode": "NULLABLE",
+		"name": "Isp2ConnectionType",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 Network Type - Should match a value for MURAKAMI_SETTINGS_NETWORK_TYPE as defined in a measurement device's environment variables. See Murakami documentation for more details.",
+		"mode": "NULLABLE",
+		"name": "Isp2NetworkType",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 ASN - The Autonomous System Number of the ISP providing service to this location. Lookup the ASN from a computer connected to this location by visiting: https://ipinfo.io ",
+		"mode": "NULLABLE",
+		"name": "Isp2ASN",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 AS Name - The Autonomous System Name of the ISP providing service to this location. Lookup the AS Name from a computer connected to this location by visiting: https://ipinfo.io ",
+		"mode": "NULLABLE",
+		"name": "Isp2ASName",
+		"type":"STRING"
+	}
+]

--- a/utilities/schemas/ndt5Schema.json
+++ b/utilities/schemas/ndt5Schema.json
@@ -1,0 +1,134 @@
+[
+	{
+		"description": "Test Name",
+		"mode": "NULLABLE",
+		"name": "TestName",
+		"type":"STRING"
+	},
+	{
+		"description": "Test Start Time",
+		"mode": "NULLABLE",
+		"name": "TestStartTime",
+		"type":"TIMESTAMP"
+	},
+	{
+		"description": "Test End Time",
+		"mode": "NULLABLE",
+		"name": "TestEndTime",
+		"type":"TIMESTAMP"
+	},
+	{
+		"description": "Murakami Location",
+		"mode": "NULLABLE",
+		"name": "MurakamiLocation",
+		"type":"STRING"
+	},
+	{
+		"description": "Murakami Connection Type",
+		"mode": "NULLABLE",
+		"name": "MurakamiConnectionType",
+		"type":"STRING"
+	},
+	{
+		"description": "Murakami Network Type",
+		"mode": "NULLABLE",
+		"name": "MurakamiNetworkType",
+		"type":"STRING"
+	},
+	{
+		"description": "Murakami Device ID",
+		"mode": "NULLABLE",
+		"name": "MurakamiDeviceID",
+		"type":"STRING"
+	},
+	{
+		"description": "Server Name",
+		"mode": "NULLABLE",
+		"name": "ServerName",
+		"type":"STRING"
+	},
+	{
+		"description": "Server IP",
+		"mode": "NULLABLE",
+		"name": "ServerIP",
+		"type":"STRING"
+	},
+	{
+		"description": "Client IP",
+		"mode": "NULLABLE",
+		"name": "ClientIP",
+		"type":"STRING"
+	},
+	{
+		"description": "Download UUID",
+		"mode": "NULLABLE",
+		"name": "DownloadUUID",
+		"type":"STRING"
+	},
+	{
+		"description": "Download Value",
+		"mode": "NULLABLE",
+		"name": "DownloadValue",
+		"type":"FLOAT"
+	},
+	{
+		"description": "Download Unit",
+		"mode": "NULLABLE",
+		"name": "DownloadUnit",
+		"type":"STRING"
+	},
+	{
+		"description": "Upload Value",
+		"mode": "NULLABLE",
+		"name": "UploadValue",
+		"type":"FLOAT"
+	},
+	{
+		"description": "Upload Unit",
+		"mode": "NULLABLE",
+		"name": "UploadUnit",
+		"type":"STRING"
+	},
+	{
+		"description": "Download Retransmission Rate Value",
+		"mode": "NULLABLE",
+		"name": "DownloadRetransValue",
+		"type":"FLOAT"
+	},
+	{
+		"description": "Download Retransmission Rate Unit",
+		"mode": "NULLABLE",
+		"name": "DownloadRetransUnit",
+		"type":"STRING"
+	},
+	{
+		"description": "Minimum Round Trip Time Value",
+		"mode": "NULLABLE",
+		"name": "MinRTTValue",
+		"type":"FLOAT"
+	},
+	{
+		"description": "Minimum Round Trip Time Unit",
+		"mode": "NULLABLE",
+		"name": "MinRTTUnit",
+		"type":"STRING"
+	},
+	{
+		"description": "Test Error",
+		"mode": "NULLABLE",
+		"name": "TestError",
+		"type":"STRING"
+	},
+	{
+		"description": "Download Error",
+		"mode": "NULLABLE",
+		"name": "DownloadError",
+		"type":"STRING"
+	},
+	{
+		"description": "Upload Error",
+		"mode": "NULLABLE",
+		"name": "UploadError",
+		"type":"STRING"
+	}
+]

--- a/utilities/schemas/ndt7Schema.json
+++ b/utilities/schemas/ndt7Schema.json
@@ -1,0 +1,134 @@
+[
+	{
+		"description": "Test Name",
+		"mode": "NULLABLE",
+		"name": "TestName",
+		"type":"STRING"
+	},
+	{
+		"description": "Test Start Time",
+		"mode": "NULLABLE",
+		"name": "TestStartTime",
+		"type":"TIMESTAMP"
+	},
+	{
+		"description": "Test End Time",
+		"mode": "NULLABLE",
+		"name": "TestEndTime",
+		"type":"TIMESTAMP"
+	},
+	{
+		"description": "Murakami Location",
+		"mode": "NULLABLE",
+		"name": "MurakamiLocation",
+		"type":"STRING"
+	},
+	{
+		"description": "Murakami Connection Type",
+		"mode": "NULLABLE",
+		"name": "MurakamiConnectionType",
+		"type":"STRING"
+	},
+	{
+		"description": "Murakami Network Type",
+		"mode": "NULLABLE",
+		"name": "MurakamiNetworkType",
+		"type":"STRING"
+	},
+	{
+		"description": "Murakami Device ID",
+		"mode": "NULLABLE",
+		"name": "MurakamiDeviceID",
+		"type":"STRING"
+	},
+	{
+		"description": "Server Name",
+		"mode": "NULLABLE",
+		"name": "ServerName",
+		"type":"STRING"
+	},
+	{
+		"description": "Server IP",
+		"mode": "NULLABLE",
+		"name": "ServerIP",
+		"type":"STRING"
+	},
+	{
+		"description": "Client IP",
+		"mode": "NULLABLE",
+		"name": "ClientIP",
+		"type":"STRING"
+	},
+	{
+		"description": "Download UUID",
+		"mode": "NULLABLE",
+		"name": "DownloadUUID",
+		"type":"STRING"
+	},
+	{
+		"description": "Download Value",
+		"mode": "NULLABLE",
+		"name": "DownloadValue",
+		"type":"FLOAT"
+	},
+	{
+		"description": "Download Unit",
+		"mode": "NULLABLE",
+		"name": "DownloadUnit",
+		"type":"STRING"
+	},
+	{
+		"description": "Upload Value",
+		"mode": "NULLABLE",
+		"name": "UploadValue",
+		"type":"FLOAT"
+	},
+	{
+		"description": "Upload Unit",
+		"mode": "NULLABLE",
+		"name": "UploadUnit",
+		"type":"STRING"
+	},
+	{
+		"description": "Download Retransmission Rate Value",
+		"mode": "NULLABLE",
+		"name": "DownloadRetransValue",
+		"type":"FLOAT"
+	},
+	{
+		"description": "Download Retransmission Rate Unit",
+		"mode": "NULLABLE",
+		"name": "DownloadRetransUnit",
+		"type":"STRING"
+	},
+	{
+		"description": "Minimum Round Trip Time Value",
+		"mode": "NULLABLE",
+		"name": "MinRTTValue",
+		"type":"FLOAT"
+	},
+	{
+		"description": "Minimum Round Trip Time Unit",
+		"mode": "NULLABLE",
+		"name": "MinRTTUnit",
+		"type":"STRING"
+	},
+	{
+		"description": "Test Error",
+		"mode": "NULLABLE",
+		"name": "TestError",
+		"type":"STRING"
+	},
+	{
+		"description": "Download Error",
+		"mode": "NULLABLE",
+		"name": "DownloadError",
+		"type":"STRING"
+	},
+	{
+		"description": "Upload Error",
+		"mode": "NULLABLE",
+		"name": "UploadError",
+		"type":"STRING"
+	}
+]

--- a/utilities/schemas/speedtestSchema.json
+++ b/utilities/schemas/speedtestSchema.json
@@ -1,0 +1,236 @@
+[
+	{
+		"description": "Test Name",
+		"mode": "NULLABLE",
+		"name": "TestName",
+		"type": "STRING"
+	},
+	{
+		"description": "Test Start Time",
+		"mode": "NULLABLE",
+		"name": "TestStartTime",
+		"type": "TIMESTAMP"
+	},
+	{
+		"description": "Test End Time",
+		"mode": "NULLABLE",
+		"name": "TestEndTime",
+		"type": "TIMESTAMP"
+	},
+	{
+		"description": "Murakami Location",
+		"mode": "NULLABLE",
+		"name": "MurakamiLocation",
+		"type": "STRING"
+	},
+	{
+		"description": "Murakami Connection Type",
+		"mode": "NULLABLE",
+		"name": "MurakamiConnectionType",
+		"type": "STRING"
+	},
+	{
+		"description": "Murakami Network Type",
+		"mode": "NULLABLE",
+		"name": "MurakamiNetworkType",
+		"type": "STRING"
+	},
+	{
+		"description": "Murakami Device ID",
+		"mode": "NULLABLE",
+		"name": "MurakamiDeviceID",
+		"type": "STRING"
+	},
+	{
+		"description": "Download Value",
+		"mode": "NULLABLE",
+		"name": "DownloadValue",
+		"type": "FLOAT"
+	},
+	{
+		"description": "Download Units",
+		"mode": "NULLABLE",
+		"name": "DownloadUnit",
+		"type": "STRING"
+	},
+	{
+		"description": "Upload Value",
+		"mode": "NULLABLE",
+		"name": "UploadValue",
+		"type": "FLOAT"
+	},
+	{
+		"description": "Upload Units",
+		"mode": "NULLABLE",
+		"name": "UploadUnit",
+		"type": "STRING"
+	},
+	{
+		"description": "Ping",
+		"mode": "NULLABLE",
+		"name": "Ping",
+		"type": "FLOAT"
+	},
+	{
+		"description": "Ping Units",
+		"mode": "NULLABLE",
+		"name": "PingUnit",
+		"type": "STRING"
+	},
+	{
+		"description": "Bytes Sent",
+		"mode": "NULLABLE",
+		"name": "BytesSent",
+		"type": "INTEGER"
+	},
+	{
+		"description": "Bytes Received",
+		"mode": "NULLABLE",
+		"name": "BytesReceived",
+		"type": "INTEGER"
+	},
+	{
+		"description": "Share",
+		"mode": "NULLABLE",
+		"name": "Share",
+		"type": "STRING"
+	},
+	{
+		"description": "Timestamp",
+		"mode": "NULLABLE",
+		"name": "Timestamp",
+		"type": "STRING"
+	},
+	{
+		"description": "Server URL",
+		"mode": "NULLABLE",
+		"name": "ServerURL",
+		"type": "STRING"
+	},
+	{
+		"description": "Server Latitude",
+		"mode": "NULLABLE",
+		"name": "ServerLat",
+		"type": "STRING"
+	},
+	{
+		"description": "Server Longitude",
+		"mode": "NULLABLE",
+		"name": "ServerLon",
+		"type": "STRING"
+	},
+	{
+		"description": "Server Name",
+		"mode": "NULLABLE",
+		"name": "ServerName",
+		"type": "STRING"
+	},
+	{
+		"description": "Server Country",
+		"mode": "NULLABLE",
+		"name": "ServerCountry",
+		"type": "STRING"
+	},
+	{
+		"description": "Server Country Code",
+		"mode": "NULLABLE",
+		"name": "ServerCountryCode",
+		"type": "STRING"
+	},
+	{
+		"description": "Server Sponsor",
+		"mode": "NULLABLE",
+		"name": "ServerSponsor",
+		"type": "STRING"
+	},
+	{
+		"description": "Server ID",
+		"mode": "NULLABLE",
+		"name": "ServerID",
+		"type": "STRING"
+	},
+	{
+		"description": "Server Host",
+		"mode": "NULLABLE",
+		"name": "ServerHost",
+		"type": "STRING"
+	},
+	{
+		"description": "Server Distance",
+		"mode": "NULLABLE",
+		"name": "ServerDistance",
+		"type": "FLOAT"
+	},
+	{
+		"description": "Server Latency",
+		"mode": "NULLABLE",
+		"name": "ServerLatency",
+		"type": "FLOAT"
+	},
+	{
+		"description": "Server Latency Unit",
+		"mode": "NULLABLE",
+		"name": "ServerLatencyUnit",
+		"type": "STRING"
+	},
+	{
+		"description": "Client IP Address",
+		"mode": "NULLABLE",
+		"name": "ClientIP",
+		"type": "STRING"
+	},
+	{
+		"description": "Client Latitude",
+		"mode": "NULLABLE",
+		"name": "ClientLat",
+		"type": "STRING"
+	},
+	{
+		"description": "Client Longitude",
+		"mode": "NULLABLE",
+		"name": "ClientLon",
+		"type": "STRING"
+	},
+	{
+		"description": "Isp",
+		"mode": "NULLABLE",
+		"name": "Isp",
+		"type": "STRING"
+	},
+	{
+		"description": "Isp Rating",
+		"mode": "NULLABLE",
+		"name": "IspRating",
+		"type": "STRING"
+	},
+	{
+		"description": "Rating",
+		"mode": "NULLABLE",
+		"name": "Rating",
+		"type": "STRING"
+	},
+	{
+		"description": "Isp Download Avg",
+		"mode": "NULLABLE",
+		"name": "IspDownloadAvg",
+		"type": "STRING"
+	},
+	{
+		"description": "Isp Upload Avg",
+		"mode": "NULLABLE",
+		"name": "IspUploadAvg",
+		"type": "STRING"
+	},
+	{
+		"description": "Logged In",
+		"mode": "NULLABLE",
+		"name": "LoggedIn",
+		"type": "STRING"
+	},
+	{
+		"description": "Country",
+		"mode": "NULLABLE",
+		"name": "Country",
+		"type": "STRING"
+	}
+]

--- a/utilities/setup_bq.sh
+++ b/utilities/setup_bq.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# This script is intended to be run once to setup GCP resources 
+# for a new measurement program that uses Murakami.
+
+# Set the variables below for your installation
+gcp_project="<gcp project>"
+bq_dataset="<bigquery dataset>"
+bq_ndt7_table="ndt7"
+bq_ndt5_table="ndt5"
+bq_speedtest_table="speedtest"
+
+# Create the dataset if it doesn't exist.
+bq show $bq_dataset || bq mk $bq_dataset
+wait
+
+# Make tables if they don't already exist.
+## ndt7 
+ndt7exists=`bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_ndt7_table'"`
+if [ -z ${ndt7exists} ]; then
+   echo "Creating $bq_ndt7_table in $gcp_project.$bq_dataset."
+   bq mk -t --description="Murakami ndt7 results table." \
+   $gcp_project:$bq_dataset.$bq_ndt7_table schemas/ndt7Schema.json
+fi
+
+## ndt5
+ndt5exists=`bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_ndt5_table'"`
+if [ -z ${ndt5exists} ]; then
+   echo "Creating $bq_ndt5_table in $gcp_project.$bq_dataset."
+   bq mk -t --description="Murakami ndt5 results table." \
+   $gcp_project:$bq_dataset.$bq_ndt5_table schemas/ndt5Schema.json
+fi
+
+## speedtest
+speedtestExists=`bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_speedtest_table'"`
+if [ -z ${speedtestExists} ]; then
+   echo "Creating $bq_speedtest_table in $gcp_project.$bq_dataset."
+   bq mk -t --description="Murakami speedtest results table." \
+   $gcp_project:$bq_dataset.$bq_speedtest_table schemas/speedtestSchema.json
+fi

--- a/utilities/setup_bq.sh
+++ b/utilities/setup_bq.sh
@@ -4,8 +4,8 @@
 # for a new measurement program that uses Murakami.
 
 # Set the variables below for your installation
-gcp_project="<gcp project>"
-bq_dataset="<bigquery dataset>"
+gcp_project="mlab-collaboration"
+bq_dataset="murakami_demo_test"
 bq_ndt7_table="ndt7"
 bq_ndt5_table="ndt5"
 bq_speedtest_table="speedtest"
@@ -38,3 +38,163 @@ if [ -z ${speedtestExists} ]; then
    bq mk -t --description="Murakami speedtest results table." \
    $gcp_project:$bq_dataset.$bq_speedtest_table schemas/speedtestSchema.json
 fi
+
+## Supporting table - locations_metadata
+locationsMetaExists=`bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='locations_metadata'"`
+if [ -z ${locationsMetaExists} ]; then
+   echo "Creating locations_metadata in $gcp_project.$bq_dataset."
+   bq mk -t --description="Metadata for locations being measured." \
+   $gcp_project:$bq_dataset.locations_metadata schemas/locationsMetaSchema.json
+fi
+
+
+# Make views
+
+## device_metadata
+bq mk --use_legacy_sql=false \
+--description "a view summarizing metadata about devices measuring in a murakami fleet" \
+--view \
+'WITH 
+ndt5 AS 
+(SELECT MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType,
+MurakamiNetworkType FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'`
+GROUP BY MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType,
+MurakamiNetworkType ),
+ndt7 AS 
+(SELECT MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType, 
+MurakamiNetworkType FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'`
+GROUP BY MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType,
+MurakamiNetworkType ),
+speedtest AS 
+(SELECT MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType, MurakamiNetworkType FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'`
+GROUP BY MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType,
+MurakamiNetworkType )
+SELECT * FROM ndt5 GROUP BY MurakamiDeviceID, MurakamiLocation,
+MurakamiConnectionType, MurakamiNetworkType
+UNION DISTINCT (SELECT * FROM ndt7)
+UNION DISTINCT (SELECT * FROM speedtest)' \
+$bq_dataset.device_metadata
+
+## server_coordinates
+
+bq mk --use_legacy_sql=false \
+--description "a view identifying the locations of all servers used to conduct tests and some metadata about each server." \
+--view \
+'WITH 
+mlabsites AS (
+  SELECT transit.asn AS asn, location.city AS city, location.country_code AS country, 
+  network.ipv4.prefix AS ipv4_prefix, network.ipv6.prefix AS ipv6_prefix, location.metro AS metro, 
+  name, transit.provider AS provider, transit.uplink AS uplink, CONCAT(location.latitude,",",location.longitude) AS coordinates 
+  FROM `mlab-collaboration.platform_meta.mlab_site_info`
+),
+locations_meta AS (
+  SELECT LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, 
+  TimeZone, PostalCode, LatLon, MurakamiLocation, Isp1Name, Isp1Type, Isp1AccessMedia, 
+  Isp1ConnectionType, Isp1NetworkType, Isp1ASN, Isp1ASName, Isp2Name, Isp2Type, Isp2AccessMedia, 
+  Isp2ConnectionType, Isp2NetworkType, Isp2ASN, Isp2ASName
+  FROM `'${gcp_project}'.'${bq_dataset}'.locations_metadata`
+),
+ndt5_client_server AS (
+  SELECT "ndt5" AS TestName, tests.MurakamiLocation, locations_meta.LatLon AS library_lat_lon, ClientIP, ServerIP, 
+  ServerName, 
+  mlabsites.coordinates AS server_lat_lon,
+  mlabsites.provider AS host,
+  CONCAT(mlabsites.city, ", ", mlabsites.country) AS ServerLocation
+  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'` tests, 
+   mlabsites, locations_meta
+  WHERE ServerName LIKE CONCAT("%",mlabsites.name,"%")
+  AND tests.MurakamiLocation = locations_meta.MurakamiLocation
+  GROUP BY TestName, MurakamiLocation, library_lat_lon, ClientIP, ServerIP, 
+  ServerName, server_lat_lon, host, ServerLocation
+),
+ndt7_client_server AS (
+  SELECT "ndt7" AS TestName, tests.MurakamiLocation, locations_meta.LatLon AS library_lat_lon, ClientIP, ServerIP, 
+  ServerName, 
+  mlabsites.coordinates AS server_lat_lon, 
+  mlabsites.provider AS host,
+  CONCAT(mlabsites.city, ", ", mlabsites.country) AS ServerLocation
+  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt7_table}'` tests, 
+   mlabsites, locations_meta
+  WHERE ServerName LIKE CONCAT("%",mlabsites.name,"%")
+  AND tests.MurakamiLocation = locations_meta.MurakamiLocation
+  GROUP BY TestName, MurakamiLocation, library_lat_lon, ClientIP, ServerIP, 
+  ServerName, server_lat_lon, host, ServerLocation
+),
+speedtest_client_server AS (
+  SELECT TestName, tests.MurakamiLocation, locations_meta.LatLon AS library_lat_lon, ClientIP, "" AS ServerIP, 
+  ServerURL AS ServerName, 
+  CONCAT(ServerLat, ", ", ServerLon) AS server_lat_lon, ServerSponsor AS host, ServerName AS ServerLocation
+  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_speedtest_table}'` tests, locations_meta
+  GROUP BY TestName, MurakamiLocation, library_lat_lon, ClientIP, ServerIP, 
+  ServerURL, server_lat_lon, host, ServerLocation
+)
+SELECT * FROM ndt5_client_server
+GROUP BY TestName, MurakamiLocation, library_lat_lon, ClientIP, ServerIP, 
+ServerName, server_lat_lon, host, ServerLocation
+UNION ALL (SELECT * FROM ndt7_client_server)
+UNION ALL (SELECT * FROM speedtest_client_server)' $bq_dataset.server_coords
+
+## Unified view of performance tests
+
+bq mk --use_legacy_sql=false \
+--description "a view combining supported performance tests: ndt5, ndt7, speedtest single, & speedtest multi, with client & server location metadata" \
+--view \
+'
+WITH
+device_metadata AS (
+  SELECT * FROM `'${gcp_project}'.'${bq_dataset}'.device_metadata`
+),
+locations_meta AS (
+  SELECT LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, 
+  TimeZone, PostalCode, LatLon, MurakamiLocation, Isp1Name, Isp1Type, Isp1AccessMedia, 
+  Isp1ConnectionType, Isp1NetworkType, Isp1ASN, Isp1ASName, Isp2Name, Isp2Type, Isp2AccessMedia, 
+  Isp2ConnectionType, Isp2NetworkType, Isp2ASN, Isp2ASName
+  FROM `'${gcp_project}'.'${bq_dataset}'.locations_metadata`
+),
+mlabsites AS (
+  SELECT transit.asn AS asn, location.city AS city, location.country_code AS country, 
+  network.ipv4.prefix AS ipv4_prefix, network.ipv6.prefix AS ipv6_prefix, location.metro AS metro, 
+  name, transit.provider AS provider, transit.uplink AS uplink, CONCAT(location.latitude,",",location.longitude) AS coordinates 
+  FROM `mlab-collaboration.platform_meta.mlab_site_info`
+),
+server_coords AS (
+  SELECT * FROM `'${gcp_project}'.'${bq_dataset}'.server_coords`
+),
+ndt5 AS (
+  SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
+  MurakamiConnectionType, MurakamiNetworkType, MurakamiDeviceID, DownloadValue, DownloadUnit, 
+  UploadValue, UploadUnit, MinRTTValue, MinRTTUnit, LocName, LocSecondaryName, LocTertiaryName, 
+  CountryName, CountryCode, TimeZone, PostalCode, LatLon, CAST(ClientIP AS STRING) AS ClientIP, 
+  DownloadUUID, CAST(ServerIP AS STRING) AS ServerIP, ServerName, mlabsites.coordinates AS server_lat_lon, 
+  mlabsites.provider AS host, CONCAT(mlabsites.city, ", ", mlabsites.country) AS ServerLocation
+  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'` tests, locations_meta meta, mlabsites
+  WHERE tests.MurakamiLocation = meta.MurakamiLocation
+  AND ServerName LIKE CONCAT("%",mlabsites.name,"%")
+),
+ndt7 AS (
+  SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
+  MurakamiConnectionType, MurakamiNetworkType, MurakamiDeviceID, DownloadValue, DownloadUnit, 
+  UploadValue, UploadUnit, MinRTTValue, MinRTTUnit, LocName, LocSecondaryName, LocTertiaryName, 
+  CountryName, CountryCode, TimeZone, PostalCode, LatLon, CAST(ClientIP AS STRING) AS ClientIP, 
+  DownloadUUID, CAST(ServerIP AS STRING) AS ServerIP, ServerName, mlabsites.coordinates AS server_lat_lon, 
+  mlabsites.provider AS host, CONCAT(mlabsites.city, ", ", mlabsites.country) AS ServerLocation
+  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt7_table}'` tests, locations_meta meta, mlabsites
+  WHERE tests.MurakamiLocation = meta.MurakamiLocation
+  AND ServerName LIKE CONCAT("%",mlabsites.name,"%")
+),
+speedtest AS (
+  SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
+  MurakamiConnectionType, MurakamiNetworkType, MurakamiDeviceID, DownloadValue/1000000 AS DownloadValue, 
+  DownloadUnit, UploadValue/1000000 AS UploadValue, UploadUnit, Ping AS MinRTTValue, PingUnit AS MinRTTUnit, 
+  LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, TimeZone, PostalCode, LatLon, 
+  CAST(ClientIP AS STRING) AS ClientIP, "" AS DownloadUUID, "" AS ServerIP, ServerURL AS ServerName, 
+  CONCAT(ServerLat, ", ", ServerLon) AS server_lat_lon, ServerSponsor AS host, ServerName AS ServerLocation
+  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_speedtest_table}'` tests, locations_meta meta
+  WHERE tests.MurakamiLocation = meta.MurakamiLocation
+),
+combined_results AS (
+  SELECT * FROM ndt5
+  UNION ALL (SELECT * FROM ndt7 )
+  UNION ALL (SELECT * FROM speedtest)
+)
+SELECT * FROM combined_results' $bq_dataset.unified_perf_tests

--- a/utilities/setup_bq.sh
+++ b/utilities/setup_bq.sh
@@ -20,7 +20,6 @@ mybucket=$gcs_bucket
 if [[ "$buckets" == *"gs://$mybucket"* ]]; then
 	echo "This GCS bucket already exists: $mybucket"
 else
-	echo "Creating GCS bucket: $mybucket"
   gsutil mb gs://$mybucket
 fi
 

--- a/utilities/setup_bq.sh
+++ b/utilities/setup_bq.sh
@@ -3,12 +3,26 @@
 # This script is intended to be run once to setup GCP resources 
 # for a new measurement program that uses Murakami.
 
-# Set the variables below for your installation
-gcp_project="mlab-collaboration"
-bq_dataset="murakami_demo_test"
+usage="$0 <project> <bucket> <dataset>"
+gcp_project=${1:?Please provide the GCP project: ${usage}}
+bucket=${2:?Please provide the GCS bucket: ${usage}}
+bq_dataset=${3:?Please provide the dataset name: ${usage}}
+
+# Set table names
 bq_ndt7_table="ndt7"
 bq_ndt5_table="ndt5"
 bq_speedtest_table="speedtest"
+
+# Create the GCS bucket if it doesn't exist.
+buckets=$(gsutil ls)
+mybucket=$bucket
+
+if [[ "$buckets" == *"gs://$mybucket"* ]]; then
+	echo "This GCS bucket already exists: $mybucket"
+else
+	echo "Creating GCS bucket: $mybucket"
+  gsutil mb gs://$mybucket
+fi
 
 # Create the dataset if it doesn't exist.
 bq show $bq_dataset || bq mk $bq_dataset
@@ -16,7 +30,7 @@ wait
 
 # Make tables if they don't already exist.
 ## ndt7 
-ndt7exists=`bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_ndt7_table'"`
+ndt7exists=$(bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_ndt7_table'")
 if [ -z ${ndt7exists} ]; then
    echo "Creating $bq_ndt7_table in $gcp_project.$bq_dataset."
    bq mk -t --description="Murakami ndt7 results table." \
@@ -24,7 +38,7 @@ if [ -z ${ndt7exists} ]; then
 fi
 
 ## ndt5
-ndt5exists=`bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_ndt5_table'"`
+ndt5exists=$(bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_ndt5_table'")
 if [ -z ${ndt5exists} ]; then
    echo "Creating $bq_ndt5_table in $gcp_project.$bq_dataset."
    bq mk -t --description="Murakami ndt5 results table." \
@@ -32,7 +46,7 @@ if [ -z ${ndt5exists} ]; then
 fi
 
 ## speedtest
-speedtestExists=`bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_speedtest_table'"`
+speedtestExists=$(bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='$bq_speedtest_table'")
 if [ -z ${speedtestExists} ]; then
    echo "Creating $bq_speedtest_table in $gcp_project.$bq_dataset."
    bq mk -t --description="Murakami speedtest results table." \
@@ -40,7 +54,7 @@ if [ -z ${speedtestExists} ]; then
 fi
 
 ## Supporting table - locations_metadata
-locationsMetaExists=`bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='locations_metadata'"`
+locationsMetaExists=$(bq query "SELECT size_bytes FROM $bq_dataset.__TABLES__ WHERE table_id='locations_metadata'")
 if [ -z ${locationsMetaExists} ]; then
    echo "Creating locations_metadata in $gcp_project.$bq_dataset."
    bq mk -t --description="Metadata for locations being measured." \
@@ -54,25 +68,25 @@ fi
 bq mk --use_legacy_sql=false \
 --description "a view summarizing metadata about devices measuring in a murakami fleet" \
 --view \
-'WITH 
+"WITH
 ndt5 AS 
 (SELECT MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType,
-MurakamiNetworkType FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'`
+MurakamiNetworkType FROM \`${gcp_project}.${bq_dataset}.${bq_ndt5_table}\`
 GROUP BY MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType,
 MurakamiNetworkType ),
 ndt7 AS 
 (SELECT MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType, 
-MurakamiNetworkType FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'`
+MurakamiNetworkType FROM \`${gcp_project}.${bq_dataset}.${bq_ndt5_table}\`
 GROUP BY MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType,
 MurakamiNetworkType ),
 speedtest AS 
-(SELECT MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType, MurakamiNetworkType FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'`
+(SELECT MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType, MurakamiNetworkType FROM \`${gcp_project}.${bq_dataset}.${bq_ndt5_table}\`
 GROUP BY MurakamiDeviceID, MurakamiLocation, MurakamiConnectionType,
 MurakamiNetworkType )
-SELECT * FROM ndt5 GROUP BY MurakamiDeviceID, MurakamiLocation,
+SELECT * FROM ${bq_ndt5_table} GROUP BY MurakamiDeviceID, MurakamiLocation,
 MurakamiConnectionType, MurakamiNetworkType
-UNION DISTINCT (SELECT * FROM ndt7)
-UNION DISTINCT (SELECT * FROM speedtest)' \
+UNION DISTINCT (SELECT * FROM ${bq_ndt7_table})
+UNION DISTINCT (SELECT * FROM ${bq_speedtest_table})" \
 $bq_dataset.device_metadata
 
 ## server_coordinates
@@ -80,51 +94,51 @@ $bq_dataset.device_metadata
 bq mk --use_legacy_sql=false \
 --description "a view identifying the locations of all servers used to conduct tests and some metadata about each server." \
 --view \
-'WITH 
+"WITH
 mlabsites AS (
   SELECT transit.asn AS asn, location.city AS city, location.country_code AS country, 
   network.ipv4.prefix AS ipv4_prefix, network.ipv6.prefix AS ipv6_prefix, location.metro AS metro, 
-  name, transit.provider AS provider, transit.uplink AS uplink, CONCAT(location.latitude,",",location.longitude) AS coordinates 
-  FROM `mlab-collaboration.platform_meta.mlab_site_info`
+  name, transit.provider AS provider, transit.uplink AS uplink, CONCAT(location.latitude,',',location.longitude) AS coordinates 
+  FROM \`mlab-collaboration.platform_meta.mlab_site_info\`
 ),
 locations_meta AS (
   SELECT LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, 
   TimeZone, PostalCode, LatLon, MurakamiLocation, Isp1Name, Isp1Type, Isp1AccessMedia, 
   Isp1ConnectionType, Isp1NetworkType, Isp1ASN, Isp1ASName, Isp2Name, Isp2Type, Isp2AccessMedia, 
   Isp2ConnectionType, Isp2NetworkType, Isp2ASN, Isp2ASName
-  FROM `'${gcp_project}'.'${bq_dataset}'.locations_metadata`
+  FROM \`${gcp_project}.${bq_dataset}.locations_metadata\`
 ),
 ndt5_client_server AS (
-  SELECT "ndt5" AS TestName, tests.MurakamiLocation, locations_meta.LatLon AS location_lat_lon, ClientIP, ServerIP, 
+  SELECT TestName, tests.MurakamiLocation, locations_meta.LatLon AS location_lat_lon, ClientIP, ServerIP, 
   ServerName, 
   mlabsites.coordinates AS server_lat_lon,
   mlabsites.provider AS host,
-  CONCAT(mlabsites.city, ", ", mlabsites.country) AS ServerLocation
-  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'` tests, 
+  CONCAT(mlabsites.city, ', ', mlabsites.country) AS ServerLocation
+  FROM \`${gcp_project}.${bq_dataset}.${bq_ndt5_table}\` tests, 
    mlabsites, locations_meta
-  WHERE ServerName LIKE CONCAT("%",mlabsites.name,"%")
+  WHERE ServerName LIKE CONCAT('%',mlabsites.name,'%')
   AND tests.MurakamiLocation = locations_meta.MurakamiLocation
   GROUP BY TestName, MurakamiLocation, location_lat_lon, ClientIP, ServerIP, 
   ServerName, server_lat_lon, host, ServerLocation
 ),
 ndt7_client_server AS (
-  SELECT "ndt7" AS TestName, tests.MurakamiLocation, locations_meta.LatLon AS location_lat_lon, ClientIP, ServerIP, 
+  SELECT TestName, tests.MurakamiLocation, locations_meta.LatLon AS location_lat_lon, ClientIP, ServerIP, 
   ServerName, 
   mlabsites.coordinates AS server_lat_lon, 
   mlabsites.provider AS host,
-  CONCAT(mlabsites.city, ", ", mlabsites.country) AS ServerLocation
-  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt7_table}'` tests, 
+  CONCAT(mlabsites.city, ', ', mlabsites.country) AS ServerLocation
+  FROM \`${gcp_project}.${bq_dataset}.${bq_ndt7_table}\` tests, 
    mlabsites, locations_meta
-  WHERE ServerName LIKE CONCAT("%",mlabsites.name,"%")
+  WHERE ServerName LIKE CONCAT('%',mlabsites.name,'%')
   AND tests.MurakamiLocation = locations_meta.MurakamiLocation
   GROUP BY TestName, MurakamiLocation, location_lat_lon, ClientIP, ServerIP, 
   ServerName, server_lat_lon, host, ServerLocation
 ),
 speedtest_client_server AS (
-  SELECT TestName, tests.MurakamiLocation, locations_meta.LatLon AS location_lat_lon, ClientIP, "" AS ServerIP, 
+  SELECT TestName, tests.MurakamiLocation, locations_meta.LatLon AS location_lat_lon, ClientIP, '' AS ServerIP, 
   ServerURL AS ServerName, 
-  CONCAT(ServerLat, ", ", ServerLon) AS server_lat_lon, ServerSponsor AS host, ServerName AS ServerLocation
-  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_speedtest_table}'` tests, locations_meta
+  CONCAT(ServerLat, ', ', ServerLon) AS server_lat_lon, ServerSponsor AS host, ServerName AS ServerLocation
+  FROM \`${gcp_project}.${bq_dataset}.${bq_speedtest_table}\` tests, locations_meta
   GROUP BY TestName, MurakamiLocation, location_lat_lon, ClientIP, ServerIP, 
   ServerURL, server_lat_lon, host, ServerLocation
 )
@@ -132,33 +146,33 @@ SELECT * FROM ndt5_client_server
 GROUP BY TestName, MurakamiLocation, location_lat_lon, ClientIP, ServerIP, 
 ServerName, server_lat_lon, host, ServerLocation
 UNION ALL (SELECT * FROM ndt7_client_server)
-UNION ALL (SELECT * FROM speedtest_client_server)' $bq_dataset.server_coords
+UNION ALL (SELECT * FROM speedtest_client_server)" $bq_dataset.server_coords
 
 ## Unified view of performance tests
 
 bq mk --use_legacy_sql=false \
 --description "a view combining supported performance tests: ndt5, ndt7, speedtest single, & speedtest multi, with client & server location metadata" \
 --view \
-'
+"
 WITH
 device_metadata AS (
-  SELECT * FROM `'${gcp_project}'.'${bq_dataset}'.device_metadata`
+  SELECT * FROM \`${gcp_project}.${bq_dataset}.device_metadata\`
 ),
 locations_meta AS (
   SELECT LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, 
   TimeZone, PostalCode, LatLon, MurakamiLocation, Isp1Name, Isp1Type, Isp1AccessMedia, 
   Isp1ConnectionType, Isp1NetworkType, Isp1ASN, Isp1ASName, Isp2Name, Isp2Type, Isp2AccessMedia, 
   Isp2ConnectionType, Isp2NetworkType, Isp2ASN, Isp2ASName
-  FROM `'${gcp_project}'.'${bq_dataset}'.locations_metadata`
+  FROM \`${gcp_project}.${bq_dataset}.locations_metadata\`
 ),
 mlabsites AS (
   SELECT transit.asn AS asn, location.city AS city, location.country_code AS country, 
   network.ipv4.prefix AS ipv4_prefix, network.ipv6.prefix AS ipv6_prefix, location.metro AS metro, 
-  name, transit.provider AS provider, transit.uplink AS uplink, CONCAT(location.latitude,",",location.longitude) AS coordinates 
-  FROM `mlab-collaboration.platform_meta.mlab_site_info`
+  name, transit.provider AS provider, transit.uplink AS uplink, CONCAT(location.latitude,',',location.longitude) AS coordinates 
+  FROM \`mlab-collaboration.platform_meta.mlab_site_info\`
 ),
 server_coords AS (
-  SELECT * FROM `'${gcp_project}'.'${bq_dataset}'.server_coords`
+  SELECT * FROM \`${gcp_project}.${bq_dataset}.server_coords\`
 ),
 ndt5 AS (
   SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
@@ -166,10 +180,10 @@ ndt5 AS (
   UploadValue, UploadUnit, MinRTTValue, MinRTTUnit, LocName, LocSecondaryName, LocTertiaryName, 
   CountryName, CountryCode, TimeZone, PostalCode, LatLon, CAST(ClientIP AS STRING) AS ClientIP, 
   DownloadUUID, CAST(ServerIP AS STRING) AS ServerIP, ServerName, mlabsites.coordinates AS server_lat_lon, 
-  mlabsites.provider AS host, CONCAT(mlabsites.city, ", ", mlabsites.country) AS ServerLocation
-  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt5_table}'` tests, locations_meta meta, mlabsites
+  mlabsites.provider AS host, CONCAT(mlabsites.city, ', ', mlabsites.country) AS ServerLocation
+  FROM \`${gcp_project}.${bq_dataset}.${bq_ndt5_table}\` tests, locations_meta meta, mlabsites
   WHERE tests.MurakamiLocation = meta.MurakamiLocation
-  AND ServerName LIKE CONCAT("%",mlabsites.name,"%")
+  AND ServerName LIKE CONCAT('%',mlabsites.name,'%')
 ),
 ndt7 AS (
   SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
@@ -177,19 +191,19 @@ ndt7 AS (
   UploadValue, UploadUnit, MinRTTValue, MinRTTUnit, LocName, LocSecondaryName, LocTertiaryName, 
   CountryName, CountryCode, TimeZone, PostalCode, LatLon, CAST(ClientIP AS STRING) AS ClientIP, 
   DownloadUUID, CAST(ServerIP AS STRING) AS ServerIP, ServerName, mlabsites.coordinates AS server_lat_lon, 
-  mlabsites.provider AS host, CONCAT(mlabsites.city, ", ", mlabsites.country) AS ServerLocation
-  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_ndt7_table}'` tests, locations_meta meta, mlabsites
+  mlabsites.provider AS host, CONCAT(mlabsites.city, ', ', mlabsites.country) AS ServerLocation
+  FROM \`${gcp_project}.${bq_dataset}.${bq_ndt7_table}\` tests, locations_meta meta, mlabsites
   WHERE tests.MurakamiLocation = meta.MurakamiLocation
-  AND ServerName LIKE CONCAT("%",mlabsites.name,"%")
+  AND ServerName LIKE CONCAT('%',mlabsites.name,'%')
 ),
 speedtest AS (
   SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
   MurakamiConnectionType, MurakamiNetworkType, MurakamiDeviceID, DownloadValue/1000000 AS DownloadValue, 
   DownloadUnit, UploadValue/1000000 AS UploadValue, UploadUnit, Ping AS MinRTTValue, PingUnit AS MinRTTUnit, 
   LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, TimeZone, PostalCode, LatLon, 
-  CAST(ClientIP AS STRING) AS ClientIP, "" AS DownloadUUID, "" AS ServerIP, ServerURL AS ServerName, 
-  CONCAT(ServerLat, ", ", ServerLon) AS server_lat_lon, ServerSponsor AS host, ServerName AS ServerLocation
-  FROM `'${gcp_project}'.'${bq_dataset}'.'${bq_speedtest_table}'` tests, locations_meta meta
+  CAST(ClientIP AS STRING) AS ClientIP, '' AS DownloadUUID, '' AS ServerIP, ServerURL AS ServerName, 
+  CONCAT(ServerLat, ', ', ServerLon) AS server_lat_lon, ServerSponsor AS host, ServerName AS ServerLocation
+  FROM \`${gcp_project}.${bq_dataset}.${bq_speedtest_table}\` tests, locations_meta meta
   WHERE tests.MurakamiLocation = meta.MurakamiLocation
 ),
 combined_results AS (
@@ -197,7 +211,7 @@ combined_results AS (
   UNION ALL (SELECT * FROM ndt7 )
   UNION ALL (SELECT * FROM speedtest)
 )
-SELECT * FROM combined_results' $bq_dataset.unified_perf_tests
+SELECT * FROM combined_results" $bq_dataset.unified_perf_tests
 
 wait
 
@@ -206,12 +220,12 @@ wait
 bq mk --use_legacy_sql=false \
 --description "a view providing the maximum measured speeds test, location, and user supplied metadata values." \
 --view \
-'SELECT
+"SELECT
 MurakamiLocation, TestName, MurakamiConnectionType, MurakamiNetworkType, 
 ROUND(MAX(DownloadValue),2) AS MaxDownload, ROUND(MAX(UploadValue),2) AS MaxUpload
-FROM `'${gcp_project}'.'${bq_dataset}'.unified_perf_tests`
+FROM \`${gcp_project}.${bq_dataset}.unified_perf_tests\`
 GROUP BY MurakamiLocation, TestName, MurakamiConnectionType, MurakamiNetworkType
-ORDER BY MurakamiLocation, TestName, MurakamiConnectionType, MurakamiNetworkType' $bq_dataset.max_by_test_location_metadata
+ORDER BY MurakamiLocation, TestName, MurakamiConnectionType, MurakamiNetworkType" $bq_dataset.max_by_test_location_metadata
 
 wait
 
@@ -220,9 +234,9 @@ wait
 bq mk --use_legacy_sql=false \
 --description "a view providing the maximum measured speeds by month and test" \
 --view \
-'SELECT
-FORMAT_DATE("%Y-%m",TestStartTime) AS YearMonth, MurakamiLocation, MurakamiConnectionType, MurakamiNetworkType, TestName,
+"SELECT
+FORMAT_DATE('%Y-%m',TestStartTime) AS YearMonth, MurakamiLocation, MurakamiConnectionType, MurakamiNetworkType, TestName,
 ROUND(MAX(DownloadValue),2) AS MaxDownload, ROUND(MAX(UploadValue),2) AS MaxUpload
-FROM `'${gcp_project}'.'${bq_dataset}'.unified_perf_tests`
+FROM \`${gcp_project}.${bq_dataset}.unified_perf_tests\`
 GROUP BY YearMonth, MurakamiLocation, MurakamiConnectionType, MurakamiNetworkType, TestName
-ORDER BY YearMonth, MurakamiLocation, MurakamiConnectionType, MurakamiNetworkType, TestName' $bq_dataset.max_by_month_test
+ORDER BY YearMonth, MurakamiLocation, MurakamiConnectionType, MurakamiNetworkType, TestName" $bq_dataset.max_by_month_test

--- a/utilities/setup_bq.sh
+++ b/utilities/setup_bq.sh
@@ -5,7 +5,7 @@
 
 usage="$0 <project> <bucket> <dataset>"
 gcp_project=${1:?Please provide the GCP project: ${usage}}
-bucket=${2:?Please provide the GCS bucket: ${usage}}
+gcs_bucket=${2:?Please provide the GCS bucket: ${usage}}
 bq_dataset=${3:?Please provide the dataset name: ${usage}}
 
 # Set table names
@@ -15,7 +15,7 @@ bq_speedtest_table="speedtest"
 
 # Create the GCS bucket if it doesn't exist.
 buckets=$(gsutil ls)
-mybucket=$bucket
+mybucket=$gcs_bucket
 
 if [[ "$buckets" == *"gs://$mybucket"* ]]; then
 	echo "This GCS bucket already exists: $mybucket"


### PR DESCRIPTION
Setting up a new set of GCP resources to support a new measurement program with a fleet of devices was a bit manual. This PR adds some automation scripts to make the setup process easier. Two scripts and associated schema files are included. @robertodauria PTAL?

* `setup_bq.sh` 
  * given a user account or service account authorized to create resources on a GCP project, set several variables: _gcp_project, bq_dataset, bq_ndt7_table, bq_ndt5_table, bq_speedtest_table_ 
  * if dataset doesn't exist, creates it
  * if tables don't exist, create them
  * create three Views: _device_metadata, server_coords, unified_perf_tests_. These views were modeled after the views used in the MLBN project, and will back a template example DataStudio report.

* `bq_load_murakami.sh`
  * Intended to be run as a daily crontab, to move test results from GCS from the prev. day into BigQuery tables.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/92)
<!-- Reviewable:end -->
