### PR TITLE
Update fields in locationsMetadata table

### DIFF
--- a/utilities/schemas/locationsMetaSchema.json
+++ b/utilities/schemas/locationsMetaSchema.json
@@ -1,5 +1,23 @@
 [
 	{
+		"description": "Device ID - The unique identifier for a device. If using Balena Cloud, this should be the UUID assigned to the device.",
+		"mode": "NULLABLE",
+		"name": "DeviceID",
+		"type":"STRING"
+	},
+	{
+		"description": "Device Metadata 1 - One of two general metadata fields used to logically define devices based on the measurement focus of a given measurement program using Murakami. For example, these could identify the ISP name and ISP service plan. They could identify the location within a network where a device is placed (e.g. egress-switch or router) and the type of connection the device has to its network (e.g. ethernet or wifi). When using the Balena Cloud scripts provided with Murakami to provision devices, these two fields must both be set.",
+		"mode": "NULLABLE",
+		"name": "DeviceMetadata1",
+		"type":"STRING"
+	},
+	{
+		"description": "Device Metadata 2 - The second of two general metadata fields used to logically define devices based on the measurement focus of a given measurement program using Murakami. For example, these could identify the ISP name and ISP service plan. They could identify the location within a network where a device is placed (e.g. egress-switch or router) and the type of connection the device has to its network (e.g. ethernet or wifi). When using the Balena Cloud scripts provided with Murakami to provision devices, these two fields must both be set.",
+		"mode": "NULLABLE",
+		"name": "DeviceMetadata2",
+		"type":"STRING"
+	},
+	{
 		"description": "Location Name - Top level name for this location.",
 		"mode": "NULLABLE",
 		"name": "LocName",
@@ -36,21 +54,9 @@
 		"type":"STRING"
 	},
 	{
-		"description": "Postal code of this location (if applicable)",
-		"mode": "NULLABLE",
-		"name": "PostalCode",
-		"type":"STRING"
-	},
-	{
 		"description": "Latitude & Longitude of this location. Format: latitude, longitude ",
 		"mode": "NULLABLE",
 		"name": "LatLon",
-		"type":"STRING"
-	},
-	{
-		"description": "Murakami Location - Should match a value for MURAKAMI_SETTINGS_LOCATION as defined in a measurement device's environment variables. See Murakami documentation for more details.",
-		"mode": "NULLABLE",
-		"name": "MurakamiLocation",
 		"type":"STRING"
 	},
 	{
@@ -72,18 +78,6 @@
 		"type":"STRING"
 	},
 	{
-		"description": "ISP 1 Connection Type - Should match a value for MURAKAMI_SETTINGS_CONNECTION_TYPE as defined in a measurement device's environment variables. See Murakami documentation for more details.",
-		"mode": "NULLABLE",
-		"name": "Isp1ConnectionType",
-		"type":"STRING"
-	},
-	{
-		"description": "ISP 1 Network Type - Should match a value for MURAKAMI_SETTINGS_NETWORK_TYPE as defined in a measurement device's environment variables. See Murakami documentation for more details.",
-		"mode": "NULLABLE",
-		"name": "Isp1NetworkType",
-		"type":"STRING"
-	},
-	{
 		"description": "ISP 1 ASN - The Autonomous System Number of the ISP providing service to this location. Lookup the ASN from a computer connected to this location by visiting: https://ipinfo.io ",
 		"mode": "NULLABLE",
 		"name": "Isp1ASN",
@@ -96,7 +90,25 @@
 		"type":"STRING"
 	},
 	{
-		"description": "ISP 2 Name - The name of this ISP as presented on terms of service, bill, or other. Can be different than ASN/AS Name.",
+		"description": "ISP 1 Service Plan - Description of the service plan for this connection. This could be the name of a plan like 'Internet Essentials' or characteristics of the plan like upload & download speeds, such as '25/3, 10/4'.",
+		"mode": "NULLABLE",
+		"name": "Isp1ServicePlan",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 1 Service Cost - The cost per month for the service plan for the connection. For example: '75', '25', or '9.95'",
+		"mode": "NULLABLE",
+		"name": "Isp1ServiceCost",
+		"type":"FLOAT"
+	},
+	{
+		"description": "ISP 1 Service Cost Units - The units for ISP 1 Service Cost. For example: 'USD' (United States Dollars) for plans within the United States.",
+		"mode": "NULLABLE",
+		"name": "Isp1ServiceCost",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 Name - The name of this ISP as presented on terms of service, bill, or other. Can be different than ASN/AS Name. 'ISP 2' fields are intended to support connections that may have dual providers that serve a single location using a load balancer.",
 		"mode": "NULLABLE",
 		"name": "Isp2Name",
 		"type":"STRING"
@@ -114,18 +126,6 @@
 		"type":"STRING"
 	},
 	{
-		"description": "ISP 2 Connection Type - Should match a value for MURAKAMI_SETTINGS_CONNECTION_TYPE as defined in a measurement device's environment variables. See Murakami documentation for more details.",
-		"mode": "NULLABLE",
-		"name": "Isp2ConnectionType",
-		"type":"STRING"
-	},
-	{
-		"description": "ISP 2 Network Type - Should match a value for MURAKAMI_SETTINGS_NETWORK_TYPE as defined in a measurement device's environment variables. See Murakami documentation for more details.",
-		"mode": "NULLABLE",
-		"name": "Isp2NetworkType",
-		"type":"STRING"
-	},
-	{
 		"description": "ISP 2 ASN - The Autonomous System Number of the ISP providing service to this location. Lookup the ASN from a computer connected to this location by visiting: https://ipinfo.io ",
 		"mode": "NULLABLE",
 		"name": "Isp2ASN",
@@ -136,5 +136,22 @@
 		"mode": "NULLABLE",
 		"name": "Isp2ASName",
 		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 Service Plan - Description of the service plan for this connection. This could be the name of a plan like 'Internet Essentials' or characteristics of the plan like upload & download speeds, such as '25/3, 10/4'.",
+		"mode": "NULLABLE",
+		"name": "Isp2ServicePlan",
+		"type":"STRING"
+	},
+	{
+		"description": "ISP 2 Service Cost - The cost per month for the service plan for the connection. For example: '75', '25', or '9.95'",
+		"mode": "NULLABLE",
+		"name": "Isp2ServiceCost",
+		"type":"FLOAT"
+	},
+	{
+		"description": "ISP 2 Service Cost Units - The units for ISP 1 Service Cost. For example: 'USD' (United States Dollars) for plans within the United States.",
+		"mode": "NULLABLE",
+		"name": "Isp2ServiceCost",
+		"type":"STRING"
 	}
-]

--- a/utilities/schemas/locationsMetaSchema.json
+++ b/utilities/schemas/locationsMetaSchema.json
@@ -1,20 +1,20 @@
 [
 	{
-		"description": "Device ID - The unique identifier for a device. If using Balena Cloud, this should be the UUID assigned to the device.",
+		"description": "Murakami Device ID - The unique identifier for a device. If using Balena Cloud, this should be the UUID assigned to the device.",
 		"mode": "NULLABLE",
-		"name": "DeviceID",
+		"name": "MurakamiDeviceID",
 		"type":"STRING"
 	},
 	{
-		"description": "Device Metadata 1 - One of two general metadata fields used to logically define devices based on the measurement focus of a given measurement program using Murakami. For example, these could identify the ISP name and ISP service plan. They could identify the location within a network where a device is placed (e.g. egress-switch or router) and the type of connection the device has to its network (e.g. ethernet or wifi). When using the Balena Cloud scripts provided with Murakami to provision devices, these two fields must both be set.",
+		"description": "Murakami Device Metadata 1 - One of two general metadata fields used to logically define devices based on the measurement focus of a given measurement program using Murakami. For example, these could identify the ISP name and ISP service plan. They could identify the location within a network where a device is placed (e.g. egress-switch or router) and the type of connection the device has to its network (e.g. ethernet or wifi). When using the Balena Cloud scripts provided with Murakami to provision devices, these two fields must both be set.",
 		"mode": "NULLABLE",
-		"name": "DeviceMetadata1",
+		"name": "MurakamiDeviceMetadata1",
 		"type":"STRING"
 	},
 	{
-		"description": "Device Metadata 2 - The second of two general metadata fields used to logically define devices based on the measurement focus of a given measurement program using Murakami. For example, these could identify the ISP name and ISP service plan. They could identify the location within a network where a device is placed (e.g. egress-switch or router) and the type of connection the device has to its network (e.g. ethernet or wifi). When using the Balena Cloud scripts provided with Murakami to provision devices, these two fields must both be set.",
+		"description": "Murakami Device Metadata 2 - The second of two general metadata fields used to logically define devices based on the measurement focus of a given measurement program using Murakami. For example, these could identify the ISP name and ISP service plan. They could identify the location within a network where a device is placed (e.g. egress-switch or router) and the type of connection the device has to its network (e.g. ethernet or wifi). When using the Balena Cloud scripts provided with Murakami to provision devices, these two fields must both be set.",
 		"mode": "NULLABLE",
-		"name": "DeviceMetadata2",
+		"name": "MurakamiDeviceMetadata2",
 		"type":"STRING"
 	},
 	{
@@ -104,7 +104,7 @@
 	{
 		"description": "ISP 1 Service Cost Units - The units for ISP 1 Service Cost. For example: 'USD' (United States Dollars) for plans within the United States.",
 		"mode": "NULLABLE",
-		"name": "Isp1ServiceCost",
+		"name": "Isp1ServiceCostUnits",
 		"type":"STRING"
 	},
 	{
@@ -152,6 +152,7 @@
 	{
 		"description": "ISP 2 Service Cost Units - The units for ISP 1 Service Cost. For example: 'USD' (United States Dollars) for plans within the United States.",
 		"mode": "NULLABLE",
-		"name": "Isp2ServiceCost",
+		"name": "Isp2ServiceCostUnits",
 		"type":"STRING"
 	}
+]

--- a/utilities/setup_bq.sh
+++ b/utilities/setup_bq.sh
@@ -101,10 +101,7 @@ mlabsites AS (
   FROM \`mlab-collaboration.platform_meta.mlab_site_info\`
 ),
 locations_meta AS (
-  SELECT LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, 
-  TimeZone, PostalCode, LatLon, MurakamiLocation, Isp1Name, Isp1Type, Isp1AccessMedia, 
-  Isp1ConnectionType, Isp1NetworkType, Isp1ASN, Isp1ASName, Isp2Name, Isp2Type, Isp2AccessMedia, 
-  Isp2ConnectionType, Isp2NetworkType, Isp2ASN, Isp2ASName
+  SELECT MurakamiDeviceID, MurakamiDeviceMetadata1, MurakamiDeviceMetadata2, LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, TimeZone, LatLon, Isp1Name, Isp1Type, Isp1AccessMedia, Isp1ASN, Isp1ASName, Isp1ServicePlan, Isp1ServiceCost, Isp1ServiceCostUnits, Isp2Name, Isp2Type, Isp2AccessMedia, Isp2ASN, Isp2ASName, Isp2ServicePlan, Isp2ServiceCost, Isp2ServiceCostUnits
   FROM \`${gcp_project}.${bq_dataset}.locations_metadata\`
 ),
 ndt5_client_server AS (
@@ -116,7 +113,7 @@ ndt5_client_server AS (
   FROM \`${gcp_project}.${bq_dataset}.${bq_ndt5_table}\` tests, 
    mlabsites, locations_meta
   WHERE ServerName LIKE CONCAT('%',mlabsites.name,'%')
-  AND tests.MurakamiLocation = locations_meta.MurakamiLocation
+  AND tests.MurakamiDeviceID = locations_meta.MurakamiDeviceID
   GROUP BY TestName, MurakamiLocation, location_lat_lon, ClientIP, ServerIP, 
   ServerName, server_lat_lon, host, ServerLocation
 ),
@@ -129,7 +126,7 @@ ndt7_client_server AS (
   FROM \`${gcp_project}.${bq_dataset}.${bq_ndt7_table}\` tests, 
    mlabsites, locations_meta
   WHERE ServerName LIKE CONCAT('%',mlabsites.name,'%')
-  AND tests.MurakamiLocation = locations_meta.MurakamiLocation
+  AND tests.MurakamiDeviceID = locations_meta.MurakamiDeviceID
   GROUP BY TestName, MurakamiLocation, location_lat_lon, ClientIP, ServerIP, 
   ServerName, server_lat_lon, host, ServerLocation
 ),
@@ -158,10 +155,7 @@ device_metadata AS (
   SELECT * FROM \`${gcp_project}.${bq_dataset}.device_metadata\`
 ),
 locations_meta AS (
-  SELECT LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, 
-  TimeZone, PostalCode, LatLon, MurakamiLocation, Isp1Name, Isp1Type, Isp1AccessMedia, 
-  Isp1ConnectionType, Isp1NetworkType, Isp1ASN, Isp1ASName, Isp2Name, Isp2Type, Isp2AccessMedia, 
-  Isp2ConnectionType, Isp2NetworkType, Isp2ASN, Isp2ASName
+  SELECT MurakamiDeviceID, MurakamiDeviceMetadata1, MurakamiDeviceMetadata2, LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, TimeZone, LatLon, Isp1Name, Isp1Type, Isp1AccessMedia, Isp1ASN, Isp1ASName, Isp1ServicePlan, Isp1ServiceCost, Isp1ServiceCostUnits, Isp2Name, Isp2Type, Isp2AccessMedia, Isp2ASN, Isp2ASName, Isp2ServicePlan, Isp2ServiceCost, Isp2ServiceCostUnits
   FROM \`${gcp_project}.${bq_dataset}.locations_metadata\`
 ),
 mlabsites AS (
@@ -175,35 +169,32 @@ server_coords AS (
 ),
 ndt5 AS (
   SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
-  MurakamiConnectionType, MurakamiNetworkType, MurakamiDeviceID, DownloadValue, DownloadUnit, 
-  UploadValue, UploadUnit, MinRTTValue, MinRTTUnit, LocName, LocSecondaryName, LocTertiaryName, 
-  CountryName, CountryCode, TimeZone, PostalCode, LatLon, CAST(ClientIP AS STRING) AS ClientIP, 
+  MurakamiConnectionType, MurakamiNetworkType, tests.MurakamiDeviceID, DownloadValue, DownloadUnit, 
+  UploadValue, UploadUnit, MinRTTValue, MinRTTUnit, meta.MurakamiDeviceMetadata1, meta.MurakamiDeviceMetadata2, meta.LocName, meta.LocSecondaryName, meta.LocTertiaryName, meta.CountryName, meta.CountryCode, meta.TimeZone, meta.LatLon, meta.Isp1Name, meta.Isp1Type, meta.Isp1AccessMedia, meta.Isp1ASN, meta.Isp1ASName, meta.Isp1ServicePlan, meta.Isp1ServiceCost, meta.Isp1ServiceCostUnits, meta.Isp2Name, meta.Isp2Type, meta.Isp2AccessMedia, meta.Isp2ASN, meta.Isp2ASName, meta.Isp2ServicePlan, meta.Isp2ServiceCost, meta.Isp2ServiceCostUnits, CAST(ClientIP AS STRING) AS ClientIP, 
   DownloadUUID, CAST(ServerIP AS STRING) AS ServerIP, ServerName, mlabsites.coordinates AS server_lat_lon, 
   mlabsites.provider AS host, CONCAT(mlabsites.city, ', ', mlabsites.country) AS ServerLocation
   FROM \`${gcp_project}.${bq_dataset}.${bq_ndt5_table}\` tests, locations_meta meta, mlabsites
-  WHERE tests.MurakamiLocation = meta.MurakamiLocation
+  WHERE tests.MurakamiDeviceID = meta.MurakamiDeviceID
   AND ServerName LIKE CONCAT('%',mlabsites.name,'%')
 ),
 ndt7 AS (
   SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
-  MurakamiConnectionType, MurakamiNetworkType, MurakamiDeviceID, DownloadValue, DownloadUnit, 
-  UploadValue, UploadUnit, MinRTTValue, MinRTTUnit, LocName, LocSecondaryName, LocTertiaryName, 
-  CountryName, CountryCode, TimeZone, PostalCode, LatLon, CAST(ClientIP AS STRING) AS ClientIP, 
+  MurakamiConnectionType, MurakamiNetworkType, tests.MurakamiDeviceID, DownloadValue, DownloadUnit, 
+  UploadValue, UploadUnit, MinRTTValue, MinRTTUnit, meta.MurakamiDeviceMetadata1, meta.MurakamiDeviceMetadata2, meta.LocName, meta.LocSecondaryName, meta.LocTertiaryName, meta.CountryName, meta.CountryCode, meta.TimeZone, meta.LatLon, meta.Isp1Name, meta.Isp1Type, meta.Isp1AccessMedia, meta.Isp1ASN, meta.Isp1ASName, meta.Isp1ServicePlan, meta.Isp1ServiceCost, meta.Isp1ServiceCostUnits, meta.Isp2Name, meta.Isp2Type, meta.Isp2AccessMedia, meta.Isp2ASN, meta.Isp2ASName, meta.Isp2ServicePlan, meta.Isp2ServiceCost, meta.Isp2ServiceCostUnits, CAST(ClientIP AS STRING) AS ClientIP, 
   DownloadUUID, CAST(ServerIP AS STRING) AS ServerIP, ServerName, mlabsites.coordinates AS server_lat_lon, 
   mlabsites.provider AS host, CONCAT(mlabsites.city, ', ', mlabsites.country) AS ServerLocation
   FROM \`${gcp_project}.${bq_dataset}.${bq_ndt7_table}\` tests, locations_meta meta, mlabsites
-  WHERE tests.MurakamiLocation = meta.MurakamiLocation
+  WHERE tests.MurakamiDeviceID = meta.MurakamiDeviceID
   AND ServerName LIKE CONCAT('%',mlabsites.name,'%')
 ),
 speedtest AS (
   SELECT TestName, DATETIME(TestStartTime, TimeZone) AS TestStartTime, tests.MurakamiLocation, 
-  MurakamiConnectionType, MurakamiNetworkType, MurakamiDeviceID, DownloadValue/1000000 AS DownloadValue, 
-  DownloadUnit, UploadValue/1000000 AS UploadValue, UploadUnit, Ping AS MinRTTValue, PingUnit AS MinRTTUnit, 
-  LocName, LocSecondaryName, LocTertiaryName, CountryName, CountryCode, TimeZone, PostalCode, LatLon, 
+  MurakamiConnectionType, MurakamiNetworkType, tests.MurakamiDeviceID, DownloadValue/1000000 AS DownloadValue, 
+  DownloadUnit, UploadValue/1000000 AS UploadValue, UploadUnit, Ping AS MinRTTValue, PingUnit AS MinRTTUnit, meta.MurakamiDeviceMetadata1, meta.MurakamiDeviceMetadata2, meta.LocName, meta.LocSecondaryName, meta.LocTertiaryName, meta.CountryName, meta.CountryCode, meta.TimeZone, meta.LatLon, meta.Isp1Name, meta.Isp1Type, meta.Isp1AccessMedia, meta.Isp1ASN, meta.Isp1ASName, meta.Isp1ServicePlan, meta.Isp1ServiceCost, meta.Isp1ServiceCostUnits, meta.Isp2Name, meta.Isp2Type, meta.Isp2AccessMedia, meta.Isp2ASN, meta.Isp2ASName, meta.Isp2ServicePlan, meta.Isp2ServiceCost, meta.Isp2ServiceCostUnits,
   CAST(ClientIP AS STRING) AS ClientIP, '' AS DownloadUUID, '' AS ServerIP, ServerURL AS ServerName, 
   CONCAT(ServerLat, ', ', ServerLon) AS server_lat_lon, ServerSponsor AS host, ServerName AS ServerLocation
   FROM \`${gcp_project}.${bq_dataset}.${bq_speedtest_table}\` tests, locations_meta meta
-  WHERE tests.MurakamiLocation = meta.MurakamiLocation
+  WHERE tests.MurakamiDeviceID = meta.MurakamiDeviceID
 ),
 combined_results AS (
   SELECT * FROM ndt5


### PR DESCRIPTION
This PR updates the names and types of some fields in the locationsMetadata table.
* Generalizes three device variables in preparation for #93 
* Removes references for the same variables from ISP specific fields (not needed with DeviceID)
* Removes PostalCode
* Adds ServicePlan, ServicePlanCost, ServicePlanCostUnits

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/95)
<!-- Reviewable:end -->
