### PR TITLE
Initialize murakami_output before usage in speedtest-cli runner

### DIFF
--- a/murakami/runners/speedtest.py
+++ b/murakami/runners/speedtest.py
@@ -41,11 +41,12 @@ class SpeedtestClient(MurakamiRunner):
             JSONDecodeError: if the output cannot be parsed as JSON.
         """
 
+        murakami_output = {}
+
         if output.returncode == 0:
             summary = {}
             summary = json.loads(output.stdout)
 
-            murakami_output = {}
             murakami_output['DownloadValue'] = summary.get('download')
             murakami_output['DownloadUnit'] = 'Bit/s'
             murakami_output['UploadValue'] = summary.get('upload')


### PR DESCRIPTION
This closes https://github.com/m-lab/murakami/issues/100.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/101)
<!-- Reviewable:end -->
