### PR TITLE
Update pip install command for speedtest-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -yq git gcc libc-dev libffi-dev libssl-dev make rustc cargo ooniprobe-cli
 RUN /usr/local/bin/python3.7 -m pip install --upgrade pip
-RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.3#egg=speedtest-cli
+RUN pip install git+https://github.com/sivel/speedtest-cli.git@v2.1.3#egg=speedtest-cli
 RUN pip install 'poetry==1.1.7'
 
 WORKDIR /murakami

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -20,7 +20,7 @@ RUN apt-get update
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get install -yq git gcc libc-dev libffi-dev libssl-dev make rustc cargo ooniprobe-cli
 RUN /usr/local/bin/python3.7 -m pip install --upgrade pip
-RUN pip install -e git://github.com/sivel/speedtest-cli.git@v2.1.3#egg=speedtest-cli
+RUN pip install git+https://github.com/sivel/speedtest-cli.git@v2.1.3#egg=speedtest-cli
 RUN pip install 'poetry==1.1.7'
 
 WORKDIR /murakami

--- a/murakami/exporter.py
+++ b/murakami/exporter.py
@@ -46,8 +46,9 @@ class MurakamiExporter:
                     test_idx += 1
                 except Exception as ex:
                     logger.error("export failed: " + ex)
+                    return False
         else:
-            self._push_single(test_name, data, timestamp)
+            return self._push_single(test_name, data, timestamp)
 
     def _push_single(self, test_name="", data=None, timestamp=None,
         test_idx=None):


### PR DESCRIPTION
This is necessary to fix the Docker build after github stopped accepting the unauthenticated git:// protocol.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/109)
<!-- Reviewable:end -->
