### PR TITLE
Correct ndt7 upload throughput parsing and add coverage

### DIFF
--- a/murakami/runners/ndt7.py
+++ b/murakami/runners/ndt7.py
@@ -97,7 +97,7 @@ class Ndt7Client(MurakamiRunner):
                         murakami_output['MinRTTValue'] = latency.get('Value')
                         murakami_output['MinRTTUnit'] = latency.get('Unit')
                 if upload is not None:
-                    throughput = download.get("Throughput")
+                    throughput = upload.get("Throughput")
                     if throughput is not None:
                         murakami_output['UploadValue'] = throughput.get('Value')
                         murakami_output['UploadUnit'] = throughput.get('Unit')

--- a/tests/test_ndt7.py
+++ b/tests/test_ndt7.py
@@ -1,0 +1,29 @@
+import json
+from unittest.mock import Mock, patch
+
+from murakami.runners.ndt7 import Ndt7Client
+
+
+def test_ndt7_upload_uses_upload_throughput():
+    summary = {
+        "ServerFQDN": "server.example",
+        "ServerIP": "203.0.113.1",
+        "ClientIP": "198.51.100.2",
+        "Download": {
+            "UUID": "download-uuid",
+            "Throughput": {"Value": 1, "Unit": "bps"},
+        },
+        "Upload": {
+            "Throughput": {"Value": 2, "Unit": "bps"},
+        },
+    }
+
+    mock_proc = Mock(returncode=0, stdout=json.dumps(summary))
+
+    with patch("shutil.which", return_value="/usr/bin/ndt7-client"):
+        with patch("subprocess.run", return_value=mock_proc):
+            runner = Ndt7Client(config={})
+            output = json.loads(runner.start_test())
+
+    assert output["DownloadValue"] == 1
+    assert output["UploadValue"] == 2


### PR DESCRIPTION
## Description
- Fixes ndt7 upload metrics to read from the upload block (not download)
- Adds a regression test that validates upload vs download throughput parsing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/123)
<!-- Reviewable:end -->
