### PR TITLE
Fix key loading tests and fallback behavior for GCS and SCP exporters (#97)

### DIFF
--- a/murakami/exporters/scp.py
+++ b/murakami/exporters/scp.py
@@ -1,7 +1,7 @@
 import io
 import logging
 import os
-
+from utilities.keys import load_key
 import jsonlines
 from paramiko import SSHClient
 from paramiko.client import AutoAddPolicy
@@ -37,7 +37,8 @@ class SCPExporter(MurakamiExporter):
         self.port = config.get("port", defaults.SSH_PORT)
         self.username = config.get("username", None)
         self.password = config.get("password", None)
-        self.private_key = config.get("key", None)
+        env_var = "MURAKAMI_EXPORTERS_SCP_KEY"
+        self.private_key = load_key(env_var=env_var, file_path=config.get("key", None))
 
     def _push_single(self, test_name="", data=None, timestamp=None,
         test_idx=None):

--- a/tests/test_key_loading.py
+++ b/tests/test_key_loading.py
@@ -1,0 +1,97 @@
+import os
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from utilities.keys import load_key, KeyLoadError
+from murakami.exporters.gcs import GCSExporter
+from murakami.exporters.scp import SCPExporter
+
+
+def create_dummy_file(content: bytes, tmp_path: Path, filename: str) -> str:
+    """
+    Write bytes to a file and return its path as a string.
+    """
+    path = tmp_path / filename
+    path.write_bytes(content)
+    return str(path)
+
+
+# Tests for GCSExporter fallback
+def test_gcs_key_fallback(tmp_path: Path, monkeypatch):
+    """
+    GCSExporter should load key file; mock storage.Client to avoid real PEM parsing.
+    """
+    key_file = tmp_path / "gcs.json"
+    # Minimal GCS JSON to trigger loading
+    key_file.write_text(json.dumps({"type": "service_account"}))
+
+    # Ensure environment variable is not set
+    monkeypatch.delenv("MURAKAMI_EXPORTERS_GCS_KEY", raising=False)
+
+    with patch("murakami.exporters.gcs.storage.Client.from_service_account_json") as MockClient:
+        exporter = GCSExporter(config={"key": key_file, "target": "dummy"})
+        # Assert that the exporter attempted to load the key
+        MockClient.assert_called_once()
+
+
+
+# Tests for SCPExporter fallback
+def test_scp_key_fallback(tmp_path: Path, monkeypatch):
+    """
+    SCPExporter should correctly read private key bytes from file.
+    """
+    key_content = b"private-key-data"
+    key_file = create_dummy_file(key_content, tmp_path, "scp.key")
+
+    monkeypatch.delenv("MURAKAMI_EXPORTERS_SCP_KEY", raising=False)
+    exporter = SCPExporter(config={"key": key_file, "target": "host:/tmp"})
+
+    # Handle Path, str, or bytes
+    if isinstance(exporter.private_key, Path):
+        actual_key = exporter.private_key.read_bytes()
+    elif isinstance(exporter.private_key, str):
+        actual_key = Path(exporter.private_key).read_bytes()
+    else:
+        actual_key = exporter.private_key
+
+    assert actual_key == key_content
+
+
+
+# Tests for load_key utility
+def test_load_key_from_env(monkeypatch):
+    """
+    Should load bytes from environment variable (base64 encoded).
+    """
+    import base64
+
+    secret = b"env-secret"
+    monkeypatch.setenv("MY_KEY_ENV", base64.b64encode(secret).decode("utf-8"))
+
+    loaded = load_key("MY_KEY_ENV", "unused_path")
+    assert loaded == secret
+
+
+def test_load_key_from_file(tmp_path: Path, monkeypatch):
+    """
+    Should load bytes from fallback file when env var not set.
+    """
+    content = b"file-secret"
+    file_path = tmp_path / "keyfile"
+    file_path.write_bytes(content)
+
+    monkeypatch.delenv("MY_KEY_ENV", raising=False)
+    loaded = load_key("MY_KEY_ENV", file_path)
+    assert loaded == content
+
+
+def test_load_key_missing(monkeypatch):
+    """
+    Should raise KeyLoadError when neither environment variable nor file exists.
+    """
+    monkeypatch.delenv("MY_KEY_ENV", raising=False)
+    with pytest.raises(KeyLoadError):
+        load_key("MY_KEY_ENV", None)

--- a/utilities/keys.py
+++ b/utilities/keys.py
@@ -1,0 +1,40 @@
+import os
+import base64
+from pathlib import Path
+from typing import Union
+
+class KeyLoadError(Exception):
+    """Raised when a key fails to load from env or file."""
+
+def load_key(
+    env_var: str,
+    file_path: Union[str, Path]
+) -> bytes:
+    """
+    Load a key from an environment variable or fallback file path.
+
+    Environment variable content must be **base64 encoded**.
+    If env var is not set, fallback to reading the file path directly.
+
+    Raises:
+        KeyLoadError: if neither source is available or decode fails.
+    """
+
+    # Try environment variable first
+    key_b64 = os.environ.get(env_var)
+    if key_b64:
+        try:
+            return base64.b64decode(key_b64.encode("utf-8"))
+        except Exception as exc:
+            raise KeyLoadError(
+                f"Failed to decode {env_var} as base64: {exc}"
+            )
+
+    # Fallback to file on disk
+    try:
+        with open(file_path, "rb") as f:
+            return f.read()
+    except Exception as exc:
+        raise KeyLoadError(
+            f"Could not load key from env {env_var} or file {file_path}: {exc}"
+        )


### PR DESCRIPTION
This PR updates tests and fallback logic for GCSExporter and SCPExporter:

- Added robust mocks for GCSExporter to avoid PEM parsing issues.
- Ensured SCPExporter reads private key bytes correctly regardless of type (str/Path/bytes).
- Updated load_key tests to properly handle environment and file fallbacks with base64 encoding.
- Cleaned up test code for readability and maintainability.

Note: This PR is NOT intended to be merged immediately. 
Feedback is requested on:
- Test coverage and edge cases
- Code readability and maintainability
- Any potential issues with key loading logic

Please review and comment on the approach before we decide how to proceed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/125)
<!-- Reviewable:end -->
