### PR TITLE
 GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - python-version: "3.6"
+            tox-env: py36
+            container-image: python:3.6-buster
+          - python-version: "3.7"
+            tox-env: py37
+            container-image: python:3.7-buster
+    container:
+      image: ${{ matrix.container-image }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache pip downloads
+        uses: actions/cache@v4
+        with:
+          path: /root/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('pyproject.toml', 'poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+
+      - name: Install CI tools (Travis before_script parity)
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U poetry tox-travis codecov tox
+
+      - name: Run tests via tox
+        run: tox -e "${{ matrix.tox-env }}"
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: .coverage
+          flags: ${{ matrix.tox-env }}
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Refs #120 

This PR adds GitHub Actions CI for Murakami

### What’s included
- Add `.github/workflows/ci.yml`
- Run `tox` tests on Python 3.6 and 3.7 (matching Travis CI test matrix)
- Install the same CI tools used in Travis (`poetry`, `tox-travis`, `codecov`)
- Upload coverage to Codecov after test jobs
- Add pip cache to speed up dependency installs across runs

### Notes
- I ran into a few issues while matching legacy Travis behavior, especially with older Python versions, and adjusted the workflow to keep behavior aligned.
- This PR is intentionally CI-only.
- I’ll open a follow-up PR for the release workflow (`release.yml`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/130)
<!-- Reviewable:end -->
