### PR TITLE
Migrate CI from Travis CI to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+    branches: [ main, master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+    
+    steps:
+    - uses: actions/checkout@v3
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Cache Poetry dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/pypoetry
+          .venv
+        key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-poetry-
+    
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python3 -
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+    
+    - name: Install dependencies
+      run: |
+        poetry install --no-interaction
+    
+    - name: Run tests
+      run: |
+        poetry run pytest -q

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+# DEPRECATED: This Travis CI configuration is no longer active.
+# CI has been migrated to GitHub Actions. See .github/workflows/ci.yml
+# This file is kept for historical reference only.
+
 language: python
 dist: xenial
 cache: pip


### PR DESCRIPTION
- Add .github/workflows/ci.yml with Python 3.10
- Update README with GitHub Actions badge
- Mark .travis.yml as deprecated
- Workflow runs poetry install and pytest on push/PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/murakami/131)
<!-- Reviewable:end -->
